### PR TITLE
Wind Fix (Only Add Initialized Winds)

### DIFF
--- a/wildfirestorage-core/src/main/java/com/sjsu/wildfirestorage/NetcdfFileReader.java
+++ b/wildfirestorage-core/src/main/java/com/sjsu/wildfirestorage/NetcdfFileReader.java
@@ -518,7 +518,8 @@ public class NetcdfFileReader {
             temp.attributeList = new ArrayList<>();
             temp.varDimensionList = new ArrayList<>();
 
-            windSpeeds.add(temp);
+            if(windSpeedMin[i]!=Integer.MAX_VALUE && windSpeedMax[i]!=0 && !Float.isNaN(temp.average))
+                windSpeeds.add(temp);
         }
         return windSpeeds;
     }


### PR DESCRIPTION
Fix wind variables to only be added to list of variables, if the min, max, avg values are initialized. Essentially, if there is at least 1 value to calculate the stats. Should help with finding documents that are relevant.