### PR TITLE
Cleanlinks cmd

### DIFF
--- a/wildstore-cli/src/main/java/edu/sjsu/wildstore/Main.java
+++ b/wildstore-cli/src/main/java/edu/sjsu/wildstore/Main.java
@@ -11,9 +11,11 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 
 public class Main {
     public static void main(String[] args) {
@@ -151,7 +153,8 @@ public class Main {
 
         @CommandLine.Command
         public void cleanlinks(@CommandLine.Mixin CliOptions co,
-                               @CommandLine.Option(names = "--no" + "-dryrun", negatable = true, defaultValue = "true") boolean dryrun) {
+                               @CommandLine.Option(names = "--no" + "-dryrun", negatable = true, defaultValue = "true") boolean dryrun) throws
+                ExecutionException, InterruptedException {
 
             List<Object> shareLinks = new ArrayList<>();
             LinkedMultiValueMap<String, String> parameters = new LinkedMultiValueMap<String, String>();
@@ -161,16 +164,21 @@ public class Main {
             parameters.add("offset", "0");
             do {
                 shareLinks = Client.get(Client.getWebClient(co.metadataURL + "/api/share-link/", co.token),
-                                      parameters,
-                                      new ParameterizedTypeReference<List<Object>>() {});
-                /*
-                if (!dryrun) System.out.println("DELETE RESULT:" + Client.post(Client.getWebClient(co.metaURL + "/api/share-link/delete", co.token),
-                                                                               deletedFiles,
+                                                         parameters,
+                                                         new ParameterizedTypeReference<List<Object>>() {});
+                shareLinks.forEach(System.out::println);
+                Map<String, String> deletedLinks = shareLinks.stream().map(dbObject -> (LinkedHashMap) dbObject)
+                        .collect(Collectors.toMap(
+                                dbObject -> ((List<String>) dbObject.get("filePath")).get(0).toString(),
+                                dbObject -> ((List<String>) dbObject.get("emailAddress")).get(0).toString()
+                        ));
+
+                if (!dryrun) System.out.println("DELETE RESULT:" + Client.post(Client.getWebClient(co.metadataURL + "/api/share-link/delete", co.token),
+                                                                               deletedLinks,
                                                                                new ParameterizedTypeReference<Integer>() {},
                                                                                httpHeaders -> httpHeaders.setBearerAuth(co.token)));
-
-                 */
-                //co.out().println("Deleted Links: " + String.join("\n", shareLinks));
+                co.out().println("Deleted Links: " + deletedLinks.entrySet().stream()
+                        .map(entry -> entry.getKey() + " " + entry.getValue()).collect(Collectors.joining("\n")));
                 offset += limit;
             } while (shareLinks.size() == limit);
             if (dryrun) System.out.println("DRYRUN: NO LINKS WERE DELETED.");

--- a/wildstore-cli/src/main/java/edu/sjsu/wildstore/Main.java
+++ b/wildstore-cli/src/main/java/edu/sjsu/wildstore/Main.java
@@ -148,6 +148,33 @@ public class Main {
             } while (result.size() == offset);
             if (dryrun) System.out.println("DRYRUN: NO FILES WERE DELETED.");
         }
+
+        @CommandLine.Command
+        public void cleanlinks(@CommandLine.Mixin CliOptions co,
+                               @CommandLine.Option(names = "--no" + "-dryrun", negatable = true, defaultValue = "true") boolean dryrun) {
+
+            List<Object> shareLinks = new ArrayList<>();
+            LinkedMultiValueMap<String, String> parameters = new LinkedMultiValueMap<String, String>();
+            int limit = 10000;
+            int offset = 0;
+            parameters.add("limit", "10000");
+            parameters.add("offset", "0");
+            do {
+                shareLinks = Client.get(Client.getWebClient(co.metadataURL + "/api/share-link/", co.token),
+                                      parameters,
+                                      new ParameterizedTypeReference<List<Object>>() {});
+                /*
+                if (!dryrun) System.out.println("DELETE RESULT:" + Client.post(Client.getWebClient(co.metaURL + "/api/share-link/delete", co.token),
+                                                                               deletedFiles,
+                                                                               new ParameterizedTypeReference<Integer>() {},
+                                                                               httpHeaders -> httpHeaders.setBearerAuth(co.token)));
+
+                 */
+                //co.out().println("Deleted Links: " + String.join("\n", shareLinks));
+                offset += limit;
+            } while (shareLinks.size() == limit);
+            if (dryrun) System.out.println("DRYRUN: NO LINKS WERE DELETED.");
+        }
     }
 
 }

--- a/wildstore-cli/src/main/java/edu/sjsu/wildstore/Main.java
+++ b/wildstore-cli/src/main/java/edu/sjsu/wildstore/Main.java
@@ -165,8 +165,8 @@ public class Main {
             LinkedMultiValueMap<String, String> parameters = new LinkedMultiValueMap<String, String>();
             int limit = 10000;
             int offset = 0;
-            parameters.add("limit", "10000");
-            parameters.add("offset", "0");
+            parameters.add("limit", String.valueOf(limit));
+            parameters.add("offset", String.valueOf(offset));
             do {
                 shareLinks = Client.get(Client.getWebClient(co.metadataURL + "/api/share-link/", co.token),
                                                          parameters,

--- a/wildstore-cli/src/main/java/edu/sjsu/wildstore/Main.java
+++ b/wildstore-cli/src/main/java/edu/sjsu/wildstore/Main.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -170,24 +171,23 @@ public class Main {
                 shareLinks = Client.get(Client.getWebClient(co.metadataURL + "/api/share-link/", co.token),
                                                          parameters,
                                                          new ParameterizedTypeReference<List<Object>>() {});
-                List<Map<String, String>> deletedLinks = shareLinks.stream()
-                        .map(obj -> (LinkedHashMap<?, ?>) obj)
-                        .filter(obj -> OffsetDateTime.parse(obj.get("expiry").toString()).toLocalDateTime().isBefore(LocalDateTime.now()))
-                        .map(obj -> {
-                            String filePath = obj.get("filePath").toString();
-                            String emailAddresses = obj.get("emailAddresses").toString();
-                            return Map.of(
-                                    "filePath", filePath,
-                                    "emailAddresses", emailAddresses
-                            );
-                        })
+                List<LinkedHashMap<?, ?>> expiredLinks = shareLinks.stream()
+                        .map(sl -> (LinkedHashMap<?, ?>) sl)
+                        .filter(sl -> OffsetDateTime.parse(sl.get("expiry").toString()).toLocalDateTime().isBefore(LocalDateTime.now()))
                         .collect(Collectors.toList());
-
-                if (!dryrun) System.out.println("DELETE RESULT:" + Client.post(Client.getWebClient(co.metadataURL + "/api/share-link/delete", co.token),
-                                                                               deletedLinks,
-                                                                               new ParameterizedTypeReference<Integer>() {},
-                                                                               httpHeaders -> httpHeaders.setBearerAuth(co.token)));
-                co.out().println("Deleted Links: " + deletedLinks.stream().map(map -> map.get("filePath") + " : " + map.get("emailAddresses")).collect(Collectors.joining("\n")));
+                if (!dryrun) {
+                    List<String> shareIds = expiredLinks.stream()
+                            .map(sl -> sl.get("_id").toString()).toList();
+                    System.out.println("DELETE RESULT:" + Client.post(Client.getWebClient(co.metadataURL + "/api/share-link/delete", co.token),
+                                                                      shareIds,
+                                                                      new ParameterizedTypeReference<Integer>() {},
+                                                                      httpHeaders -> httpHeaders.setBearerAuth(co.token)));
+                }
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+                co.out().println("Deleted ShareLinks: " + expiredLinks.size());
+                expiredLinks.forEach(sl -> {
+                    co.out().println("File path: " + sl.get("filePath").toString() + ", Emails: " + sl.get("emailAddresses").toString() + ", Expired on: " + (OffsetDateTime.parse(sl.get("expiry").toString())).format(formatter));
+                });
                 offset += limit;
             } while (shareLinks.size() == limit);
             if (dryrun) System.out.println("DRYRUN: NO LINKS WERE DELETED.");

--- a/wildstore-cli/src/main/java/edu/sjsu/wildstore/Main.java
+++ b/wildstore-cli/src/main/java/edu/sjsu/wildstore/Main.java
@@ -1,5 +1,6 @@
 package edu.sjsu.wildstore;
 
+import com.mongodb.DBObject;
 import edu.sjsu.wildstore.meta.controller.ShareLinkController;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.util.LinkedMultiValueMap;
@@ -9,11 +10,14 @@ import picocli.CommandLine;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
@@ -166,19 +170,24 @@ public class Main {
                 shareLinks = Client.get(Client.getWebClient(co.metadataURL + "/api/share-link/", co.token),
                                                          parameters,
                                                          new ParameterizedTypeReference<List<Object>>() {});
-                shareLinks.forEach(System.out::println);
-                Map<String, String> deletedLinks = shareLinks.stream().map(dbObject -> (LinkedHashMap) dbObject)
-                        .collect(Collectors.toMap(
-                                dbObject -> ((List<String>) dbObject.get("filePath")).get(0).toString(),
-                                dbObject -> ((List<String>) dbObject.get("emailAddress")).get(0).toString()
-                        ));
+                List<Map<String, String>> deletedLinks = shareLinks.stream()
+                        .map(obj -> (LinkedHashMap<?, ?>) obj)
+                        .filter(obj -> OffsetDateTime.parse(obj.get("expiry").toString()).toLocalDateTime().isBefore(LocalDateTime.now()))
+                        .map(obj -> {
+                            String filePath = obj.get("filePath").toString();
+                            String emailAddresses = obj.get("emailAddresses").toString();
+                            return Map.of(
+                                    "filePath", filePath,
+                                    "emailAddresses", emailAddresses
+                            );
+                        })
+                        .collect(Collectors.toList());
 
                 if (!dryrun) System.out.println("DELETE RESULT:" + Client.post(Client.getWebClient(co.metadataURL + "/api/share-link/delete", co.token),
                                                                                deletedLinks,
                                                                                new ParameterizedTypeReference<Integer>() {},
                                                                                httpHeaders -> httpHeaders.setBearerAuth(co.token)));
-                co.out().println("Deleted Links: " + deletedLinks.entrySet().stream()
-                        .map(entry -> entry.getKey() + " " + entry.getValue()).collect(Collectors.joining("\n")));
+                co.out().println("Deleted Links: " + deletedLinks.stream().map(map -> map.get("filePath") + " : " + map.get("emailAddresses")).collect(Collectors.joining("\n")));
                 offset += limit;
             } while (shareLinks.size() == limit);
             if (dryrun) System.out.println("DRYRUN: NO LINKS WERE DELETED.");

--- a/wildstore-cli/src/test/java/edu/sjsu/wildstore/CliTest.java
+++ b/wildstore-cli/src/test/java/edu/sjsu/wildstore/CliTest.java
@@ -45,6 +45,9 @@ import static java.lang.String.format;
 public class CliTest {
     private static ConfigurableApplicationContext springCtx;
     private static String metaURL;
+    public static final String USER_DATA_COLLECTION = "userData";
+    public static final String METADATA_COLLECTION = "metadata";
+    public static final String SHARE_LINKS_COLLECTION = "share-links";
 
     @Configuration
     public static class TestOAuthSecurityConfig {
@@ -76,9 +79,9 @@ public class CliTest {
             }
         }
         metaURL = "http://localhost:" + port;
-        springCtx.getBean(MongoTemplate.class).createCollection("userData");
-        springCtx.getBean(MongoTemplate.class).createCollection("metadata");
-        springCtx.getBean(MongoTemplate.class).createCollection("share-links");
+        springCtx.getBean(MongoTemplate.class).createCollection(USER_DATA_COLLECTION);
+        springCtx.getBean(MongoTemplate.class).createCollection(METADATA_COLLECTION);
+        springCtx.getBean(MongoTemplate.class).createCollection(SHARE_LINKS_COLLECTION);
     }
 
     @AfterAll
@@ -159,7 +162,7 @@ public class CliTest {
         Assertions.assertEquals("", result.err);
         Assertions.assertEquals(1, result.out.split("\n").length);
 
-        deleteUsers("@example.com");
+        emptyCollections();
     }
 
     @Test
@@ -188,8 +191,8 @@ public class CliTest {
         testMeta2.fileName = new HashSet<String>(Set.of(testDataPath2.toAbsolutePath().toString()));
         testMeta2.filePath = new HashSet<String>(Set.of(testDataPath2.toAbsolutePath().getParent().toString()));
         testMeta2.digestString = testDigest2;
-        springCtx.getBean(MongoTemplate.class).insert(testMeta, "metadata");
-        springCtx.getBean(MongoTemplate.class).insert(testMeta2, "metadata");
+        springCtx.getBean(MongoTemplate.class).insert(testMeta, METADATA_COLLECTION);
+        springCtx.getBean(MongoTemplate.class).insert(testMeta2, METADATA_COLLECTION);
 
         createUser("ROLE_USER", "ShareUser", "user@share", userToken);
         createUser("ROLE_GUEST", "ShareGuest", "guest@share", guestToken);
@@ -241,21 +244,21 @@ public class CliTest {
         Assertions.assertTrue(result.out.contains("?filename=test-data.txt") && result.out.contains("?filename=test-data-2.txt") && !result.err.contains("Missing Files"));
         Query query = new Query(Criteria.where("fileDigest").is(testDigest));
         LocalDateTime oldTime = Objects.requireNonNull(springCtx.getBean(MongoTemplate.class)
-                                                               .findOne(query, ShareLink.class, "share-links")).expiry;
+                                                               .findOne(query, ShareLink.class, SHARE_LINKS_COLLECTION)).expiry;
 
         result = clirun(cmd, "share", testDataPath.toString(), "/testfile", "--metaURL", metaURL, "--token", userTokenFile.toString(), "--email", "user@share", "--validFor", "year");
         Assertions.assertEquals(0, result.exitCode);
         Assertions.assertTrue(result.out.contains("?filename=test-data.txt") && result.err.contains("/testfile"));
         LocalDateTime newTime = Objects.requireNonNull(springCtx.getBean(MongoTemplate.class)
-                                                               .findOne(query, ShareLink.class, "share-links")).expiry;
+                                                               .findOne(query, ShareLink.class, SHARE_LINKS_COLLECTION)).expiry;
         Assertions.assertTrue(newTime.isAfter(oldTime));
 
         // make sure the expiry time stays the same after sharing with shorter validFor time
         result = clirun(cmd, "share", testDataPath.toString(), testDataPath2.toString(), "--metaURL", metaURL, "--token", userTokenFile.toString(), "--email", "user@share", "--validFor", "day");
         Assertions.assertEquals(newTime, Objects.requireNonNull(springCtx.getBean(MongoTemplate.class)
-                                                               .findOne(query, ShareLink.class, "share-links")).expiry);
+                                                               .findOne(query, ShareLink.class, SHARE_LINKS_COLLECTION)).expiry);
 
-        deleteUsers("@share");
+        emptyCollections();
     }
 
     @Test
@@ -299,7 +302,7 @@ public class CliTest {
                                        "all",
                                        false);
         }
-        Assertions.assertEquals(2, springCtx.getBean(MongoTemplate.class).getCollection("metadata").countDocuments());
+        Assertions.assertEquals(2, springCtx.getBean(MongoTemplate.class).getCollection(METADATA_COLLECTION).countDocuments());
 
         var deletedFile = fileNames.get(0);
         Files.delete(Paths.get(fileNames.get(0)));
@@ -319,18 +322,18 @@ public class CliTest {
         result = clirun(cmd, "clean", "--metaURL", metaURL, "--token", adminTokenFile.toString());
         Assertions.assertEquals(0, result.exitCode);
         Assertions.assertTrue(result.out.contains(deletedFile));
-        Assertions.assertEquals(2, springCtx.getBean(MongoTemplate.class).getCollection("metadata").countDocuments());
+        Assertions.assertEquals(2, springCtx.getBean(MongoTemplate.class).getCollection(METADATA_COLLECTION).countDocuments());
 
         result = clirun(cmd, "clean", "--metaURL", metaURL, "--token", adminTokenFile.toString(), "--dryrun");
         Assertions.assertEquals(0, result.exitCode);
         Assertions.assertTrue(result.out.contains(deletedFile));
-        Assertions.assertEquals(2, springCtx.getBean(MongoTemplate.class).getCollection("metadata").countDocuments());
+        Assertions.assertEquals(2, springCtx.getBean(MongoTemplate.class).getCollection(METADATA_COLLECTION).countDocuments());
 
         // file should be deleted
         result = clirun(cmd, "clean", "--metaURL", metaURL, "--token", adminTokenFile.toString(), "--no-dryrun");
         Assertions.assertEquals(0, result.exitCode);
         Assertions.assertTrue(result.out.contains(deletedFile));
-        Assertions.assertEquals(0, springCtx.getBean(MongoTemplate.class).getCollection("metadata").countDocuments());
+        Assertions.assertEquals(0, springCtx.getBean(MongoTemplate.class).getCollection(METADATA_COLLECTION).countDocuments());
 
         // crawl more files
         for (int i = 2; i < Math.min(32, fileNames.size()); i++) {
@@ -361,7 +364,7 @@ public class CliTest {
                 });
 
         var result2 = clirun(cmd, "clean", "--metaURL", metaURL, "--token", adminTokenFile.toString(), "--no-dryrun");
-        Assertions.assertEquals(15, springCtx.getBean(MongoTemplate.class).getCollection("metadata").countDocuments());
+        Assertions.assertEquals(15, springCtx.getBean(MongoTemplate.class).getCollection(METADATA_COLLECTION).countDocuments());
         IntStream.range(0, deletedFiles.size())
                 .forEach(i -> {
                     Assertions.assertTrue(result2.out().contains(deletedFiles.get(i)),
@@ -378,7 +381,7 @@ public class CliTest {
                         }
                     });
         }
-        deleteUsers("@clean");
+        emptyCollections();
     }
 
     @Test
@@ -407,8 +410,8 @@ public class CliTest {
         testMeta2.fileName = new HashSet<String>(Set.of(testDataFile2.toString()));
         testMeta2.filePath = new HashSet<String>(Set.of(testDataPath2.getParent().toString()));
         testMeta2.digestString = testDigest2;
-        springCtx.getBean(MongoTemplate.class).insert(testMeta, "metadata");
-        springCtx.getBean(MongoTemplate.class).insert(testMeta2, "metadata");
+        springCtx.getBean(MongoTemplate.class).insert(testMeta, METADATA_COLLECTION);
+        springCtx.getBean(MongoTemplate.class).insert(testMeta2, METADATA_COLLECTION);
 
         clirun(cmd, "share", testDataPath.toString(), testDataPath2.toString(), "--metaURL", metaURL, "--token", adminTokenFile.toString(), "--email", "admin@cleanlinks", "--validFor", "day");
 
@@ -425,11 +428,13 @@ public class CliTest {
         // links should be deleted
         springCtx.getBean(MongoTemplate.class)
                 .updateMulti(new Query(Criteria.where("expiry").gt(LocalDateTime.now())),
-                            new org.springframework.data.mongodb.core.query.Update().set("expiry", LocalDateTime.now().minus(Duration.ofDays(1))), "share-links");
+                            new org.springframework.data.mongodb.core.query.Update().set("expiry", LocalDateTime.now().minus(Duration.ofDays(1))), SHARE_LINKS_COLLECTION);
         result = clirun(cmd, "cleanlinks", "--metaURL", metaURL, "--token", adminTokenFile.toString(), "--no-dryrun");
         Assertions.assertEquals(0, result.exitCode);
         Assertions.assertTrue(result.out.contains("Deleted ShareLinks: 2"));
-        Assertions.assertTrue(springCtx.getBean(MongoTemplate.class).getCollection("share-links").countDocuments() == 0);
+        Assertions.assertTrue(springCtx.getBean(MongoTemplate.class).getCollection(SHARE_LINKS_COLLECTION).countDocuments() == 0);
+
+        emptyCollections();
     }
 
     private static void createUser(String role, String name, String email, String token) {
@@ -438,12 +443,14 @@ public class CliTest {
                          "name", name,
                          "email", email,
                          "token", token);
-        springCtx.getBean(MongoTemplate.class).insert(new HashMap(rec), "userData");
+        springCtx.getBean(MongoTemplate.class).insert(new HashMap(rec), USER_DATA_COLLECTION);
     }
 
-    private static void deleteUsers(String keyword) {
-        var query = new Query(Criteria.where("email").regex(keyword));
-        springCtx.getBean(MongoTemplate.class).remove(query, "userData");
+    private static void emptyCollections() {
+        var query = new Query();
+        springCtx.getBean(MongoTemplate.class).remove(query, USER_DATA_COLLECTION);
+        springCtx.getBean(MongoTemplate.class).remove(query, METADATA_COLLECTION);
+        springCtx.getBean(MongoTemplate.class).remove(query, SHARE_LINKS_COLLECTION);
     }
 
     record TestResult(int exitCode, String out, String err) {}

--- a/wildstore-cli/src/test/java/edu/sjsu/wildstore/CliTest.java
+++ b/wildstore-cli/src/test/java/edu/sjsu/wildstore/CliTest.java
@@ -411,8 +411,6 @@ public class CliTest {
         springCtx.getBean(MongoTemplate.class).insert(testMeta2, "metadata");
 
         clirun(cmd, "share", testDataPath.toString(), testDataPath2.toString(), "--metaURL", metaURL, "--token", adminTokenFile.toString(), "--email", "admin@cleanlinks", "--validFor", "day");
-        //Query query = new Query(Criteria.where("fileDigest").is(testDigest));
-        //ShareLink sl = springCtx.getBean(MongoTemplate.class).find();
 
         // should not delete links that are not expired
         var result = clirun(cmd, "cleanlinks", "--metaURL", metaURL, "--token", adminTokenFile.toString());
@@ -420,19 +418,17 @@ public class CliTest {
         Assertions.assertFalse(result.out.contains("/") && result.out.contains("@"));
 
         // dryrun should not delete anything
-        Clock fixedClock = Clock.fixed(Instant.now().plus(Duration.ofHours(2)), ZoneId.systemDefault());
-        LocalDateTime mockedNow = LocalDateTime.now(fixedClock);
         result = clirun(cmd, "cleanlinks", "--metaURL", metaURL, "--token", adminTokenFile.toString(), "--dryrun");
-        System.out.println(result);
         Assertions.assertEquals(0, result.exitCode);
         Assertions.assertFalse(result.out.contains("/") && result.out.contains("@"));
 
         // links should be deleted
+        springCtx.getBean(MongoTemplate.class)
+                .updateMulti(new Query(Criteria.where("expiry").gt(LocalDateTime.now())),
+                            new org.springframework.data.mongodb.core.query.Update().set("expiry", LocalDateTime.now().minus(Duration.ofDays(1))), "share-links");
         result = clirun(cmd, "cleanlinks", "--metaURL", metaURL, "--token", adminTokenFile.toString(), "--no-dryrun");
-        System.out.println(result);
         Assertions.assertEquals(0, result.exitCode);
-        Assertions.assertFalse(result.out.contains("/") && result.out.contains("@"));
-
+        Assertions.assertTrue(result.out.contains("Deleted ShareLinks: 2"));
     }
 
     private static void createUser(String role, String name, String email, String token) {

--- a/wildstore-cli/src/test/java/edu/sjsu/wildstore/CliTest.java
+++ b/wildstore-cli/src/test/java/edu/sjsu/wildstore/CliTest.java
@@ -23,7 +23,11 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -409,9 +413,26 @@ public class CliTest {
         clirun(cmd, "share", testDataPath.toString(), testDataPath2.toString(), "--metaURL", metaURL, "--token", adminTokenFile.toString(), "--email", "admin@cleanlinks", "--validFor", "day");
         //Query query = new Query(Criteria.where("fileDigest").is(testDigest));
         //ShareLink sl = springCtx.getBean(MongoTemplate.class).find();
-        //LocalDateTime.now().plusDays(1);
+
+        // should not delete links that are not expired
         var result = clirun(cmd, "cleanlinks", "--metaURL", metaURL, "--token", adminTokenFile.toString());
+        Assertions.assertEquals(0, result.exitCode);
+        Assertions.assertFalse(result.out.contains("/") && result.out.contains("@"));
+
+        // dryrun should not delete anything
+        Clock fixedClock = Clock.fixed(Instant.now().plus(Duration.ofHours(2)), ZoneId.systemDefault());
+        LocalDateTime mockedNow = LocalDateTime.now(fixedClock);
+        result = clirun(cmd, "cleanlinks", "--metaURL", metaURL, "--token", adminTokenFile.toString(), "--dryrun");
         System.out.println(result);
+        Assertions.assertEquals(0, result.exitCode);
+        Assertions.assertFalse(result.out.contains("/") && result.out.contains("@"));
+
+        // links should be deleted
+        result = clirun(cmd, "cleanlinks", "--metaURL", metaURL, "--token", adminTokenFile.toString(), "--no-dryrun");
+        System.out.println(result);
+        Assertions.assertEquals(0, result.exitCode);
+        Assertions.assertFalse(result.out.contains("/") && result.out.contains("@"));
+
     }
 
     private static void createUser(String role, String name, String email, String token) {

--- a/wildstore-cli/src/test/java/edu/sjsu/wildstore/CliTest.java
+++ b/wildstore-cli/src/test/java/edu/sjsu/wildstore/CliTest.java
@@ -429,6 +429,7 @@ public class CliTest {
         result = clirun(cmd, "cleanlinks", "--metaURL", metaURL, "--token", adminTokenFile.toString(), "--no-dryrun");
         Assertions.assertEquals(0, result.exitCode);
         Assertions.assertTrue(result.out.contains("Deleted ShareLinks: 2"));
+        Assertions.assertTrue(springCtx.getBean(MongoTemplate.class).getCollection("share-links").countDocuments() == 0);
     }
 
     private static void createUser(String role, String name, String email, String token) {

--- a/wildstore-cli/src/test/java/edu/sjsu/wildstore/CliTest.java
+++ b/wildstore-cli/src/test/java/edu/sjsu/wildstore/CliTest.java
@@ -178,8 +178,8 @@ public class CliTest {
         var testMeta2 = new Metadata();
         var testDigest = "dummy-digest";
         var testDigest2 = "dummy-digest-2";
-        testMeta.fileName = new HashSet<String>(Set.of(testDataFile.toAbsolutePath().toString()));
-        testMeta.filePath = new HashSet<String>(Set.of(testDataFile.toAbsolutePath().getParent().toString()));
+        testMeta.fileName = new HashSet<String>(Set.of(testDataPath.toAbsolutePath().toString()));
+        testMeta.filePath = new HashSet<String>(Set.of(testDataPath.toAbsolutePath().getParent().toString()));
         testMeta.digestString = testDigest;
         testMeta2.fileName = new HashSet<String>(Set.of(testDataPath2.toAbsolutePath().toString()));
         testMeta2.filePath = new HashSet<String>(Set.of(testDataPath2.toAbsolutePath().getParent().toString()));
@@ -375,6 +375,43 @@ public class CliTest {
                     });
         }
         deleteUsers("@clean");
+    }
+
+    @Test
+    void testCleanLinks() throws IOException {
+        var cmd = new Main.Cli();
+        var adminTokenFile = tempDir.resolve("admin-token.txt");
+        var userTokenFile = tempDir.resolve("user-token.txt");
+        var adminToken = "secret-admin-token";
+        var userToken = "secret-user-token";
+        Files.write(adminTokenFile, ("token=" + adminToken).getBytes());
+        Files.write(userTokenFile, ("token=" + userToken).getBytes());
+        createUser("ROLE_ADMIN", "CleanAdmin", "admin@cleanlinks", adminToken);
+        createUser("ROLE_USER", "ClearUser", "user@cleanlinks", userToken);
+
+        var testDataFile = tempDir.resolve("test-data.txt");
+        var testDataFile2 = tempDir.resolve("test-data-2.txt");
+        var testDataPath = testDataFile.toAbsolutePath();
+        var testDataPath2 = testDataFile2.toAbsolutePath();
+        var testMeta = new Metadata();
+        var testMeta2 = new Metadata();
+        var testDigest = "dummy-digest";
+        var testDigest2 = "dummy-digest-2";
+        testMeta.fileName = new HashSet<String>(Set.of(testDataPath.toString()));
+        testMeta.filePath = new HashSet<String>(Set.of(testDataPath.getParent().toString()));
+        testMeta.digestString = testDigest;
+        testMeta2.fileName = new HashSet<String>(Set.of(testDataFile2.toString()));
+        testMeta2.filePath = new HashSet<String>(Set.of(testDataPath2.getParent().toString()));
+        testMeta2.digestString = testDigest2;
+        springCtx.getBean(MongoTemplate.class).insert(testMeta, "metadata");
+        springCtx.getBean(MongoTemplate.class).insert(testMeta2, "metadata");
+
+        clirun(cmd, "share", testDataPath.toString(), testDataPath2.toString(), "--metaURL", metaURL, "--token", adminTokenFile.toString(), "--email", "admin@cleanlinks", "--validFor", "day");
+        //Query query = new Query(Criteria.where("fileDigest").is(testDigest));
+        //ShareLink sl = springCtx.getBean(MongoTemplate.class).find();
+        //LocalDateTime.now().plusDays(1);
+        var result = clirun(cmd, "cleanlinks", "--metaURL", metaURL, "--token", adminTokenFile.toString());
+        System.out.println(result);
     }
 
     private static void createUser(String role, String name, String email, String token) {

--- a/wildstore-cli/src/test/java/edu/sjsu/wildstore/CliTest.java
+++ b/wildstore-cli/src/test/java/edu/sjsu/wildstore/CliTest.java
@@ -415,8 +415,18 @@ public class CliTest {
 
         clirun(cmd, "share", testDataPath.toString(), testDataPath2.toString(), "--metaURL", metaURL, "--token", adminTokenFile.toString(), "--email", "admin@cleanlinks", "--validFor", "day");
 
+        // users can dryrun cleanlinks
+        var result = clirun(cmd, "cleanlinks", "--metaURL", metaURL, "--token", userTokenFile.toString());
+        Assertions.assertEquals(0, result.exitCode);
+        Assertions.assertTrue(result.out.contains("Deleted ShareLinks: 0"));
+
+        result = clirun(cmd, "cleanlinks", "--metaURL", metaURL, "--token", userTokenFile.toString(), "--no-dryrun");
+        Assertions.assertEquals(1, result.exitCode);
+        Assertions.assertTrue(result.err.contains("WebClientResponseException"));
+
         // should not delete links that are not expired
-        var result = clirun(cmd, "cleanlinks", "--metaURL", metaURL, "--token", adminTokenFile.toString());
+
+        result = clirun(cmd, "cleanlinks", "--metaURL", metaURL, "--token", adminTokenFile.toString());
         Assertions.assertEquals(0, result.exitCode);
         Assertions.assertFalse(result.out.contains("/") && result.out.contains("@"));
 

--- a/wildstore-meta/src/main/java/edu/sjsu/wildstore/meta/controller/MetadataController.java
+++ b/wildstore-meta/src/main/java/edu/sjsu/wildstore/meta/controller/MetadataController.java
@@ -168,8 +168,8 @@ public class MetadataController {
 
     @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/metadata/filenames")
-    public int deleteMetadata(@RequestBody List<String> filePaths) {
-        Query query = new Query(Criteria.where("fileName").in(filePaths));
+    public int deleteMetadata(@RequestBody List<String> fileNames) {
+        Query query = new Query(Criteria.where("fileName").in(fileNames));
         return (int) mongoTemplate.remove(query, METADATA_COLLECTION).getDeletedCount();
     }
 

--- a/wildstore-meta/src/main/java/edu/sjsu/wildstore/meta/controller/ShareLinkController.java
+++ b/wildstore-meta/src/main/java/edu/sjsu/wildstore/meta/controller/ShareLinkController.java
@@ -189,10 +189,12 @@ public class ShareLinkController {
 
     @PreAuthorize("hasRole('USER')")
     @GetMapping("/")
-    public List<DBObject> getShareLinkList(OAuth2AuthenticationToken oAuth2AuthenticationToken,
+    public List<DBObject> getShareLinkList(Authentication authentication,
                                            @RequestParam(defaultValue = "100") int limit,
                                            @RequestParam(defaultValue = "0") int offset) {
-        String email = UserInfo.getUserId(oAuth2AuthenticationToken);
+        if (authentication instanceof OAuth2AuthenticationToken oAuth2AuthenticationToken) {
+            String email = UserInfo.getUserId(oAuth2AuthenticationToken);
+        }
         Query query = new Query(Criteria.where("createdBy").is(getCurrentUserName()));
         query.limit(limit);
         query.skip(offset);
@@ -213,6 +215,19 @@ public class ShareLinkController {
     public boolean deleteShareLink(@PathVariable String shareId) {
         try {
             Query query = new Query(Criteria.where("shareId").is(shareId));
+            mongoTemplate.remove(query, DBObject.class, "share-links");
+            return true;
+        } catch (Exception ex) {
+            System.out.println(ex.getMessage());
+            return false;
+        }
+    }
+
+    @PreAuthorize("hasRole('USER')")
+    @PostMapping("/delete")
+    public boolean deleteShareLinks(@RequestBody List<String> shareId) {
+        try {
+            Query query = new Query(Criteria.where("shareId").in(shareId));
             mongoTemplate.remove(query, DBObject.class, "share-links");
             return true;
         } catch (Exception ex) {

--- a/wildstore-meta/src/main/java/edu/sjsu/wildstore/meta/controller/ShareLinkController.java
+++ b/wildstore-meta/src/main/java/edu/sjsu/wildstore/meta/controller/ShareLinkController.java
@@ -225,15 +225,9 @@ public class ShareLinkController {
 
     @PreAuthorize("hasRole('USER')")
     @PostMapping("/delete")
-    public boolean deleteShareLinks(@RequestBody List<String> shareId) {
-        try {
-            Query query = new Query(Criteria.where("shareId").in(shareId));
-            mongoTemplate.remove(query, DBObject.class, "share-links");
-            return true;
-        } catch (Exception ex) {
-            System.out.println(ex.getMessage());
-            return false;
-        }
+    public int deleteShareLinks(@RequestBody List<String> shareId) {
+        Query query = new Query(Criteria.where("shareId").in(shareId));
+        return (int) mongoTemplate.remove(query, DBObject.class, "share-links").getDeletedCount();
     }
 
     @PreAuthorize("hasRole('GUEST')")

--- a/wildstore-meta/src/main/java/edu/sjsu/wildstore/meta/controller/ShareLinkController.java
+++ b/wildstore-meta/src/main/java/edu/sjsu/wildstore/meta/controller/ShareLinkController.java
@@ -192,9 +192,6 @@ public class ShareLinkController {
     public List<DBObject> getShareLinkList(Authentication authentication,
                                            @RequestParam(defaultValue = "100") int limit,
                                            @RequestParam(defaultValue = "0") int offset) {
-        if (authentication instanceof OAuth2AuthenticationToken oAuth2AuthenticationToken) {
-            String email = UserInfo.getUserId(oAuth2AuthenticationToken);
-        }
         Query query = new Query(Criteria.where("createdBy").is(getCurrentUserName()));
         query.limit(limit);
         query.skip(offset);
@@ -210,7 +207,7 @@ public class ShareLinkController {
         return mongoTemplate.count(query, "share-links");
     }
 
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{shareId}")
     public boolean deleteShareLink(@PathVariable String shareId) {
         try {
@@ -223,7 +220,7 @@ public class ShareLinkController {
         }
     }
 
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/delete")
     public int deleteShareLinks(@RequestBody List<String> shareId) {
         Query query = new Query(Criteria.where("_id").in(shareId));

--- a/wildstore-meta/src/main/java/edu/sjsu/wildstore/meta/controller/ShareLinkController.java
+++ b/wildstore-meta/src/main/java/edu/sjsu/wildstore/meta/controller/ShareLinkController.java
@@ -214,8 +214,8 @@ public class ShareLinkController {
     @DeleteMapping("/{shareId}")
     public boolean deleteShareLink(@PathVariable String shareId) {
         try {
-            Query query = new Query(Criteria.where("shareId").is(shareId));
-            mongoTemplate.remove(query, DBObject.class, "share-links");
+            Query query = new Query(Criteria.where("_id").is(shareId));
+            mongoTemplate.remove(query, SHARE_LINKS_COLLECTION);
             return true;
         } catch (Exception ex) {
             System.out.println(ex.getMessage());
@@ -226,8 +226,8 @@ public class ShareLinkController {
     @PreAuthorize("hasRole('USER')")
     @PostMapping("/delete")
     public int deleteShareLinks(@RequestBody List<String> shareId) {
-        Query query = new Query(Criteria.where("shareId").in(shareId));
-        return (int) mongoTemplate.remove(query, DBObject.class, "share-links").getDeletedCount();
+        Query query = new Query(Criteria.where("_id").in(shareId));
+        return (int) mongoTemplate.remove(query, SHARE_LINKS_COLLECTION).getDeletedCount();
     }
 
     @PreAuthorize("hasRole('GUEST')")


### PR DESCRIPTION
The cleanlinks command will only be able to clean sharelinks created with an @id shareId field. Old sharelinks will have an automatically created _id and a shareId field.