### PR TITLE
Old sharelinks can be cleaned and accessed now

### DIFF
--- a/wildstore-cli/src/main/java/edu/sjsu/wildstore/Main.java
+++ b/wildstore-cli/src/main/java/edu/sjsu/wildstore/Main.java
@@ -1,6 +1,5 @@
 package edu.sjsu.wildstore;
 
-import com.mongodb.DBObject;
 import edu.sjsu.wildstore.meta.controller.ShareLinkController;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.util.LinkedMultiValueMap;
@@ -11,14 +10,12 @@ import picocli.CommandLine;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
@@ -173,11 +170,11 @@ public class Main {
                                                          new ParameterizedTypeReference<List<Object>>() {});
                 List<LinkedHashMap<?, ?>> expiredLinks = shareLinks.stream()
                         .map(sl -> (LinkedHashMap<?, ?>) sl)
-                        .filter(sl -> OffsetDateTime.parse(sl.get("expiry").toString()).toLocalDateTime().isBefore(LocalDateTime.now()))
+                        .filter(sl -> LocalDateTime.parse(sl.get("expiry").toString()).isBefore(LocalDateTime.now()))
                         .collect(Collectors.toList());
                 if (!dryrun) {
                     List<String> shareIds = expiredLinks.stream()
-                            .map(sl -> sl.get("_id").toString()).toList();
+                            .map(sl -> sl.get("shareId").toString()).toList();
                     System.out.println("DELETE RESULT:" + Client.post(Client.getWebClient(co.metadataURL + "/api/share-link/delete", co.token),
                                                                       shareIds,
                                                                       new ParameterizedTypeReference<Integer>() {},
@@ -186,7 +183,7 @@ public class Main {
                 DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
                 co.out().println("Deleted ShareLinks: " + expiredLinks.size());
                 expiredLinks.forEach(sl -> {
-                    co.out().println("File path: " + sl.get("filePath").toString() + ", Emails: " + sl.get("emailAddresses").toString() + ", Expired on: " + (OffsetDateTime.parse(sl.get("expiry").toString())).format(formatter));
+                    co.out().println("File path: " + sl.get("filePath").toString() + ", Emails: " + sl.get("emailAddresses").toString() + ", Expired on: " + (LocalDateTime.parse(sl.get("expiry").toString())).format(formatter));
                 });
                 offset += limit;
             } while (shareLinks.size() == limit);

--- a/wildstore-meta/src/main/java/edu/sjsu/wildstore/meta/controller/OauthController.java
+++ b/wildstore-meta/src/main/java/edu/sjsu/wildstore/meta/controller/OauthController.java
@@ -81,7 +81,7 @@ public class OauthController {
 
     public String getOpaqueToken(OAuth2AuthenticationToken user) {
         String name = user.getPrincipal().getAttribute("name");
-        String email = UserInfo.getUserId(user);
+        String email = UserInfo.getUserEmail(user);
         Query query = new Query(Criteria.where("email").is(email));
         var opaqueTokenMap = mongoTemplate.find(query, Map.class, USER_COLLECTION);
         String opaqueToken = null;

--- a/wildstore-meta/src/main/java/edu/sjsu/wildstore/meta/controller/ShareLinkController.java
+++ b/wildstore-meta/src/main/java/edu/sjsu/wildstore/meta/controller/ShareLinkController.java
@@ -19,15 +19,26 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.DefaultOAuth2AuthenticatedPrincipal;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.springframework.http.HttpStatus.NOT_FOUND;
@@ -189,20 +200,22 @@ public class ShareLinkController {
 
     @PreAuthorize("hasRole('USER')")
     @GetMapping("/")
-    public List<DBObject> getShareLinkList(Authentication authentication,
-                                           @RequestParam(defaultValue = "100") int limit,
-                                           @RequestParam(defaultValue = "0") int offset) {
-        Query query = new Query(Criteria.where("createdBy").is(getCurrentUserEmail()));
+    public List<ShareLink> getShareLinkList(Authentication authentication,
+                                            @RequestParam(defaultValue = "100") int limit,
+                                            @RequestParam(defaultValue = "0") int offset) {
+        Query query = new Query(new Criteria().orOperator(Criteria.where("createdBy").is(getCurrentUserEmail()),
+                                                          Criteria.where("createdBy").is(getCurrentUserName())));
         query.limit(limit);
         query.skip(offset);
-        List<DBObject> res = mongoTemplate.find(query, DBObject.class, "share-links");
+        List<ShareLink> res = mongoTemplate.find(query, ShareLink.class, "share-links");
         return res;
     }
 
     @PreAuthorize("hasRole('USER')")
     @GetMapping("/count")
     public long getShareLinkCount(Authentication authentication) {
-        Query query = new Query(Criteria.where("createdBy").is(getCurrentUserEmail()));
+        Query query = new Query(new Criteria().orOperator(Criteria.where("createdBy").is(getCurrentUserEmail()),
+                                                          Criteria.where("createdBy").is(getCurrentUserName())));
         return mongoTemplate.count(query, "share-links");
     }
 
@@ -210,15 +223,22 @@ public class ShareLinkController {
     @DeleteMapping("/{shareId}")
     public boolean deleteShareLink(@PathVariable String shareId, Authentication authentication) {
         String email = UserInfo.getUserEmail(authentication);
-        Query query = new Query(Criteria.where("shareId").is(shareId));
-        query.addCriteria(Criteria.where("createdBy").is(email));
+        Query query = new Query(new Criteria().andOperator(new Criteria().orOperator(Criteria.where("_id").is(shareId),
+                                                                                     Criteria.where("shareId")
+                                                                                             .is(shareId)),
+                                                           new Criteria().orOperator(Criteria.where("createdBy")
+                                                                                             .is(getCurrentUserEmail()),
+                                                                                     Criteria.where("createdBy")
+                                                                                             .is(getCurrentUserName()))
+        ));
         return mongoTemplate.remove(query, SHARE_LINKS_COLLECTION).getDeletedCount() > 0;
     }
 
     @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/delete")
     public int deleteShareLinks(@RequestBody List<String> shareId) {
-        Query query = new Query(Criteria.where("_id").in(shareId));
+        Query query = new Query(new Criteria().orOperator(Criteria.where("_id").in(shareId),
+                                                          Criteria.where("shareId").in(shareId)));
         return (int) mongoTemplate.remove(query, SHARE_LINKS_COLLECTION).getDeletedCount();
     }
 
@@ -283,11 +303,11 @@ public class ShareLinkController {
     private String getCurrentUserName() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth.getPrincipal() instanceof DefaultOAuth2User) {
-            return (String) ((DefaultOAuth2User) (auth.getPrincipal())).getAttribute("name");
+            return ((DefaultOAuth2User) (auth.getPrincipal())).getAttribute("name");
         } else if (auth.getPrincipal() instanceof DefaultOAuth2AuthenticatedPrincipal) {
-            return (String) ((DefaultOAuth2AuthenticatedPrincipal) (auth.getPrincipal())).getAttribute("name");
+            return ((DefaultOAuth2AuthenticatedPrincipal) (auth.getPrincipal())).getAttribute("name");
         } else {
-            return (String) ((DefaultOidcUser) (auth.getPrincipal())).getAttribute("name");
+            return ((DefaultOidcUser) (auth.getPrincipal())).getAttribute("name");
         }
     }
 
@@ -296,9 +316,9 @@ public class ShareLinkController {
         if (auth.getPrincipal() instanceof DefaultOAuth2AuthenticatedPrincipal) {
             return ((DefaultOAuth2AuthenticatedPrincipal) (auth.getPrincipal())).getAttribute("email");
         } else if (auth.getPrincipal() instanceof DefaultOAuth2User) {
-            return (String) ((DefaultOAuth2User) (auth.getPrincipal())).getAttribute("email");
+            return ((DefaultOAuth2User) (auth.getPrincipal())).getAttribute("email");
         } else {
-            return (String) ((DefaultOidcUser) (auth.getPrincipal())).getAttribute("email");
+            return ((DefaultOidcUser) (auth.getPrincipal())).getAttribute("email");
         }
     }
 

--- a/wildstore-meta/src/main/java/edu/sjsu/wildstore/meta/controller/ShareLinkController.java
+++ b/wildstore-meta/src/main/java/edu/sjsu/wildstore/meta/controller/ShareLinkController.java
@@ -203,6 +203,7 @@ public class ShareLinkController {
     public List<ShareLink> getShareLinkList(Authentication authentication,
                                             @RequestParam(defaultValue = "100") int limit,
                                             @RequestParam(defaultValue = "0") int offset) {
+        // old sharelinks are created with username in field createdBy
         Query query = new Query(new Criteria().orOperator(Criteria.where("createdBy").is(getCurrentUserEmail()),
                                                           Criteria.where("createdBy").is(getCurrentUserName())));
         query.limit(limit);
@@ -214,6 +215,7 @@ public class ShareLinkController {
     @PreAuthorize("hasRole('USER')")
     @GetMapping("/count")
     public long getShareLinkCount(Authentication authentication) {
+        // old sharelinks are created with username in field createdBy
         Query query = new Query(new Criteria().orOperator(Criteria.where("createdBy").is(getCurrentUserEmail()),
                                                           Criteria.where("createdBy").is(getCurrentUserName())));
         return mongoTemplate.count(query, "share-links");
@@ -223,6 +225,8 @@ public class ShareLinkController {
     @DeleteMapping("/{shareId}")
     public boolean deleteShareLink(@PathVariable String shareId, Authentication authentication) {
         String email = UserInfo.getUserEmail(authentication);
+        // old sharelinks are created with shareId and username in field createdBy
+        // new sharelines are created with _id and email in field createdBy
         Query query = new Query(new Criteria().andOperator(new Criteria().orOperator(Criteria.where("_id").is(shareId),
                                                                                      Criteria.where("shareId")
                                                                                              .is(shareId)),
@@ -237,6 +241,7 @@ public class ShareLinkController {
     @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/delete")
     public int deleteShareLinks(@RequestBody List<String> shareId) {
+        // old sharelinks are created with shareId
         Query query = new Query(new Criteria().orOperator(Criteria.where("_id").in(shareId),
                                                           Criteria.where("shareId").in(shareId)));
         return (int) mongoTemplate.remove(query, SHARE_LINKS_COLLECTION).getDeletedCount();

--- a/wildstore-meta/src/main/java/edu/sjsu/wildstore/meta/controller/ShareLinkController.java
+++ b/wildstore-meta/src/main/java/edu/sjsu/wildstore/meta/controller/ShareLinkController.java
@@ -80,7 +80,7 @@ public class ShareLinkController {
         if (!res.isEmpty()) {
             Map<String, Metadata> existingDigests = res.stream().collect(Collectors.toMap(m -> m.digestString, m -> m));
             Query linkQuery = new Query(Criteria.where("fileDigest").in(existingDigests.keySet()));
-            linkQuery.addCriteria(Criteria.where("createdBy").is(getCurrentUserName()));
+            linkQuery.addCriteria(Criteria.where("createdBy").is(getCurrentUserEmail()));
             linkQuery.addCriteria(Criteria.where("emailAddresses").all(request.get("emailAddresses")));
             linkQuery.addCriteria(Criteria.where("expiry").gt(LocalDateTime.now()));
             List<ShareLink> existing = mongoTemplate.find(linkQuery, ShareLink.class, SHARE_LINKS_COLLECTION);
@@ -122,7 +122,7 @@ public class ShareLinkController {
                     ShareLink shareLink = new ShareLink();
                     shareLink.fileDigest = digest;
                     shareLink.filePath = existingDigests.get(digest).filePath;
-                    shareLink.createdBy = getCurrentUserName();
+                    shareLink.createdBy = getCurrentUserEmail();
                     shareLink.shareId = UUID.randomUUID().toString().replace("-", "");
                     shareLink.createdAt = LocalDateTime.now();
                     shareLink.emailAddresses = new HashSet<String>((ArrayList<String>) request.get("emailAddresses"));
@@ -192,7 +192,7 @@ public class ShareLinkController {
     public List<DBObject> getShareLinkList(Authentication authentication,
                                            @RequestParam(defaultValue = "100") int limit,
                                            @RequestParam(defaultValue = "0") int offset) {
-        Query query = new Query(Criteria.where("createdBy").is(getCurrentUserName()));
+        Query query = new Query(Criteria.where("createdBy").is(getCurrentUserEmail()));
         query.limit(limit);
         query.skip(offset);
         List<DBObject> res = mongoTemplate.find(query, DBObject.class, "share-links");
@@ -201,23 +201,18 @@ public class ShareLinkController {
 
     @PreAuthorize("hasRole('USER')")
     @GetMapping("/count")
-    public long getShareLinkCount(OAuth2AuthenticationToken oAuth2AuthenticationToken) {
-        String email = UserInfo.getUserId(oAuth2AuthenticationToken);
-        Query query = new Query(Criteria.where("createdBy").is(getCurrentUserName()));
+    public long getShareLinkCount(Authentication authentication) {
+        Query query = new Query(Criteria.where("createdBy").is(getCurrentUserEmail()));
         return mongoTemplate.count(query, "share-links");
     }
 
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasRole('USER')")
     @DeleteMapping("/{shareId}")
-    public boolean deleteShareLink(@PathVariable String shareId) {
-        try {
-            Query query = new Query(Criteria.where("_id").is(shareId));
-            mongoTemplate.remove(query, SHARE_LINKS_COLLECTION);
-            return true;
-        } catch (Exception ex) {
-            System.out.println(ex.getMessage());
-            return false;
-        }
+    public boolean deleteShareLink(@PathVariable String shareId, Authentication authentication) {
+        String email = UserInfo.getUserEmail(authentication);
+        Query query = new Query(Criteria.where("shareId").is(shareId));
+        query.addCriteria(Criteria.where("createdBy").is(email));
+        return mongoTemplate.remove(query, SHARE_LINKS_COLLECTION).getDeletedCount() > 0;
     }
 
     @PreAuthorize("hasRole('ADMIN')")

--- a/wildstore-meta/src/main/java/edu/sjsu/wildstore/meta/util/UserInfo.java
+++ b/wildstore-meta/src/main/java/edu/sjsu/wildstore/meta/util/UserInfo.java
@@ -4,7 +4,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
 import org.springframework.stereotype.Controller;
 
 import java.util.Map;
@@ -48,12 +49,22 @@ public class UserInfo {
         return null;
     }
 
-    public static String getUserId(OAuth2AuthenticationToken user) {
+    public static String getUserEmail(Authentication user) {
         System.out.println(user.getPrincipal().getClass());
-        String email = user.getPrincipal().getAttribute("email");
+        OAuth2AuthenticatedPrincipal principal = (OAuth2AuthenticatedPrincipal) user.getPrincipal();
+        String email = principal.getAttribute("email");
         if (email == null) {
-            email = user.getPrincipal().getAttribute("login") + "@github";
+            var githubLogin = principal.getAttribute("login");
+            if (githubLogin != null) {
+                email = principal.getAttribute("login") + "@github";
+            }
         }
         return email;
+    }
+
+    public static String getUserName(Authentication user) {
+        System.out.println(user.getPrincipal().getClass());
+        OAuth2AuthenticatedPrincipal principal = (OAuth2AuthenticatedPrincipal) user.getPrincipal();
+        return principal.getAttribute("name");
     }
 }


### PR DESCRIPTION
Sharelinks created without an @id field and/or a username in field createdBy can show up on web broswer sharelink list and be cleaned by cleanlinks cmd.