### PR TITLE
no-walk

### DIFF
--- a/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
+++ b/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
@@ -294,6 +294,7 @@ public class WildfireFilesCrawler implements Runnable {
         NetcdfFileReader fileReader = new NetcdfFileReader(file);
         var metadata = fileReader.processFile(maxReadSize);
 
+        System.out.println("Crawling file: " + file);
         if (option.equals("all")) {
             PrintData.printAllData(metadata);
         } else if (option.equals("basic")) {

--- a/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
+++ b/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
@@ -34,6 +34,7 @@ import java.util.stream.Stream;
 
 @CommandLine.Command(name = "GET", mixinStandardHelpOptions = true)
 public class WildfireFilesCrawler implements Runnable {
+    private static final String DONE_SENTINEL = "DONE";
     @CommandLine.Option(names = "--option", defaultValue = "all", description = "Which information to print - 'all' or 'basic'")
     private String option;
     @CommandLine.Parameters(paramLabel = "<file>", description = "Path to the file containing list of NetCDF files to process", arity = "1")
@@ -69,6 +70,39 @@ public class WildfireFilesCrawler implements Runnable {
         return spec.commandLine();
     }
 
+    private class WalkerThread extends Thread {
+        private final Path pathToWalk;
+        private final LinkedBlockingQueue<String> pathNameQueue;
+
+        WalkerThread(Path pathToWalk, LinkedBlockingQueue<String> pathNameQueue) {
+            this.pathToWalk = pathToWalk;
+            this.pathNameQueue = pathNameQueue;
+        }
+        @Override
+        public void run() {
+            try {
+                Files.walkFileTree(pathToWalk, new SimpleFileVisitor<Path>() {
+                    @Override
+                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                        if (file.toFile().isFile() && file.toString().endsWith(".nc")) {
+                            pathNameQueue.offer(file.toString());
+                        }
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    @Override
+                    public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+                        err().println("Error visiting file: " + file + " - " + exc.getClass().getName());
+                        return FileVisitResult.CONTINUE;
+                    }
+                });
+            } catch (IOException e) {
+                err().println("Error walking file tree: " + e.getMessage());
+            } finally {
+                pathNameQueue.offer(DONE_SENTINEL);
+            }
+        }
+    }
     public void run() {
         var okayException = new Exception("No exception");
         Properties appProps = new Properties();
@@ -120,28 +154,16 @@ public class WildfireFilesCrawler implements Runnable {
             var exceptions = stream.flatMap( fileName -> {
                 File file = new File(fileName);
                 if (file.isDirectory()) {
-                    var fileList = new LinkedList<String>();
-                    try {
-                        // Use Files.walkFileTree rather than Files.walk to not stop on exceptions
-                        Files.walkFileTree(file.toPath(), new SimpleFileVisitor<>() {
-                            @Override
-                            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                                if (Files.isRegularFile(file) && file.toString().endsWith(".nc")) {
-                                    fileList.add(file.toString());
-                                }
-                                return FileVisitResult.CONTINUE;
-                            }
-
-                            @Override
-                            public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
-                                err().printf("Error visiting file %s: %s%n", file, exc.getMessage());
-                                return FileVisitResult.CONTINUE;
-                            }
-                        });
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                    return fileList.stream();
+                    var nameQueue = new LinkedBlockingQueue<String>();
+                    new WalkerThread(file.toPath(), nameQueue).start();
+                    return Stream.generate(() -> {
+                        try {
+                            return nameQueue.take();
+                        } catch (InterruptedException e) {
+                            return DONE_SENTINEL;
+                        }
+                        // for sentinel value use == not equals!
+                    }).takeWhile(s -> s != DONE_SENTINEL);
                 } else {
                     return Stream.of(fileName);
                 }

--- a/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
+++ b/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
@@ -85,7 +85,11 @@ public class WildfireFilesCrawler implements Runnable {
                     @Override
                     public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                         if (file.toFile().isFile() && file.toString().endsWith(".nc")) {
-                            pathNameQueue.offer(file.toString());
+                            try {
+                                pathNameQueue.put(file.toString());
+                            } catch (InterruptedException e) {
+                                return FileVisitResult.TERMINATE;
+                            }
                         }
                         return FileVisitResult.CONTINUE;
                     }
@@ -169,7 +173,7 @@ public class WildfireFilesCrawler implements Runnable {
                     } else {
                         return Stream.of(fileName);
                     }
-                }).filter(file -> {
+                }).parallel().filter(file -> {
                     try {
                         if (fileNamesMap.containsKey(file) &&
                                 fileNamesMap.get(file) >= Files.getLastModifiedTime(Paths.get(file)).toMillis()) {
@@ -183,7 +187,7 @@ public class WildfireFilesCrawler implements Runnable {
                                                                          e.getMessage(),
                                                                  e);
                     }
-                }).parallel().map(file -> {
+                }).map(file -> {
                     try {
                         if (crawl(file, webClient, maxReadSize, option, enumLog)) {
                             crawledCount.getAndIncrement();

--- a/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
+++ b/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
@@ -31,10 +31,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 @CommandLine.Command(name = "GET", mixinStandardHelpOptions = true)
 public class WildfireFilesCrawler implements Runnable {
-    private static final String DONE_SENTINEL = "DONE";
     @CommandLine.Option(names = "--option", defaultValue = "all", description = "Which information to print - 'all' or 'basic'")
     private String option;
     @CommandLine.Parameters(paramLabel = "<file>", description = "Path to the file containing list of NetCDF files to process", arity = "1")
@@ -70,41 +70,72 @@ public class WildfireFilesCrawler implements Runnable {
         return spec.commandLine();
     }
 
-    private class WalkerThread extends Thread {
-        private final Path pathToWalk;
-        private final LinkedBlockingQueue<String> pathNameQueue;
-
-        WalkerThread(Path pathToWalk, LinkedBlockingQueue<String> pathNameQueue) {
-            this.pathToWalk = pathToWalk;
-            this.pathNameQueue = pathNameQueue;
+    static private class FileSpliterator extends java.util.Spliterators.AbstractSpliterator<Path> {
+        private static final long POPULATE_QUEUE_SIZE = 1000;
+        private ConcurrentLinkedQueue<Path> dirQueue = new ConcurrentLinkedQueue<>();
+        private ConcurrentLinkedQueue<Path> fileQueue = new ConcurrentLinkedQueue<>();
+        FileSpliterator(List<Path> pathsToWalk) {
+            super(Long.MAX_VALUE, java.util.Spliterator.NONNULL);
+            this.dirQueue.addAll(pathsToWalk);
+            populateFileQueue();
         }
-        @Override
-        public void run() {
-            try {
-                Files.walkFileTree(pathToWalk, new SimpleFileVisitor<Path>() {
-                    @Override
-                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                        if (file.toFile().isFile() && file.toString().endsWith(".nc")) {
-                            try {
-                                pathNameQueue.put(file.toString());
-                            } catch (InterruptedException e) {
-                                return FileVisitResult.TERMINATE;
-                            }
-                        }
-                        return FileVisitResult.CONTINUE;
-                    }
 
-                    @Override
-                    public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
-                        err().println("Error visiting file: " + file + " - " + exc.getClass().getName());
-                        return FileVisitResult.CONTINUE;
-                    }
-                });
-            } catch (IOException e) {
-                err().println("Error walking file tree: " + e.getMessage());
-            } finally {
-                pathNameQueue.offer(DONE_SENTINEL);
+        private FileSpliterator(ConcurrentLinkedQueue<Path> dirQueue, ConcurrentLinkedQueue<Path> fileQueue) {
+            super(Long.MAX_VALUE, java.util.Spliterator.NONNULL);
+            this.dirQueue = dirQueue;
+            this.fileQueue = fileQueue;
+        }
+
+        private long populateFileQueue() {
+            long count = 0;
+            // try to get 1000 files into the fileQueue
+            while (count < POPULATE_QUEUE_SIZE && !dirQueue.isEmpty()) {
+                Path dir = dirQueue.poll();
+                if (dir == null) continue;
+                try (var stream = Files.list(dir)) {
+                    count += stream.filter(p -> {
+                        if (p.toFile().isDirectory()) {
+                            dirQueue.add(p);
+                            return false;
+                        } else if (p.toFile().isFile() && p.toString().endsWith(".nc")) {
+                            fileQueue.add(p);
+                            return true;
+                        } else {
+                            return false;
+                        }
+                    }).limit(POPULATE_QUEUE_SIZE).count();
+                } catch (IOException e) {
+                    System.err.println("Error listing directory: " + dir + " - " + e.getClass().getName());
+                }
             }
+            return count;
+        }
+
+        @Override
+        synchronized public boolean tryAdvance(java.util.function.Consumer<? super Path> action) {
+            var path = fileQueue.poll();
+            if (path != null) {
+                action.accept(path);
+                return true;
+            }
+            while (true) {
+                populateFileQueue();
+                path = fileQueue.poll();
+                if (path == null && dirQueue.isEmpty()) return false;
+                if (path != null) {
+                    action.accept(path);
+                    return true;
+                }
+            }
+        }
+
+        @Override
+        synchronized public FileSpliterator trySplit() {
+            var count = populateFileQueue();
+            if (count < POPULATE_QUEUE_SIZE) {
+                return null; // Not enough files to split
+            }
+            return new FileSpliterator(this.dirQueue, this.fileQueue);
         }
     }
     public void run() {
@@ -152,7 +183,6 @@ public class WildfireFilesCrawler implements Runnable {
                         map -> (Long) map.get("lastModified"),
                         Long::min));
 
-        out().printf("Processing files %d at a time%n", parallelism);
         ForkJoinPool customPool = new ForkJoinPool(parallelism); // set desired parallelism
 
         var poolResult = customPool.submit(() -> {
@@ -160,16 +190,7 @@ public class WildfireFilesCrawler implements Runnable {
                 var exceptions = stream.flatMap(fileName -> {
                     File file = new File(fileName);
                     if (file.isDirectory()) {
-                        var nameQueue = new LinkedBlockingQueue<String>();
-                        new WalkerThread(file.toPath(), nameQueue).start();
-                        return Stream.generate(() -> {
-                            try {
-                                return nameQueue.take();
-                            } catch (InterruptedException e) {
-                                return DONE_SENTINEL;
-                            }
-                            // for sentinel value use == not equals!
-                        }).takeWhile(s -> s != DONE_SENTINEL);
+                         return StreamSupport.stream(new FileSpliterator(List.of(file.toPath())), true).map(Path::toString);
                     } else {
                         return Stream.of(fileName);
                     }

--- a/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
+++ b/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
@@ -13,12 +13,16 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -116,12 +120,28 @@ public class WildfireFilesCrawler implements Runnable {
             var exceptions = stream.flatMap( fileName -> {
                 File file = new File(fileName);
                 if (file.isDirectory()) {
+                    var fileList = new LinkedList<String>();
                     try {
-                        return Files.walk(file.toPath()).filter(Files::isRegularFile).map(Path::toString)
-                                .filter(string -> string.endsWith(".nc"));
+                        // Use Files.walkFileTree rather than Files.walk to not stop on exceptions
+                        Files.walkFileTree(file.toPath(), new SimpleFileVisitor<>() {
+                            @Override
+                            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                                if (Files.isRegularFile(file) && file.toString().endsWith(".nc")) {
+                                    fileList.add(file.toString());
+                                }
+                                return FileVisitResult.CONTINUE;
+                            }
+
+                            @Override
+                            public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+                                err().printf("Error visiting file %s: %s%n", file, exc.getMessage());
+                                return FileVisitResult.CONTINUE;
+                            }
+                        });
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
+                    return fileList.stream();
                 } else {
                     return Stream.of(fileName);
                 }
@@ -241,6 +261,7 @@ public class WildfireFilesCrawler implements Runnable {
         CommandLine commandLine = new CommandLine(new WildfireFilesCrawler());
         commandLine.setExecutionExceptionHandler((ex, cl, pr) -> {
             System.err.println(ex.getMessage());
+            ex.printStackTrace();
             return 2;
         });
         commandLine.setParameterExceptionHandler((ex, as) -> {

--- a/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
+++ b/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
@@ -72,18 +72,21 @@ public class WildfireFilesCrawler implements Runnable {
 
     static private class FileSpliterator extends java.util.Spliterators.AbstractSpliterator<Path> {
         private static final long POPULATE_QUEUE_SIZE = 1000;
-        private ConcurrentLinkedQueue<Path> dirQueue = new ConcurrentLinkedQueue<>();
-        private ConcurrentLinkedQueue<Path> fileQueue = new ConcurrentLinkedQueue<>();
+        // all split FileSpliter instances share the same queue of directories to walk
+        final private ConcurrentLinkedQueue<Path> dirQueue;
+        // each instance has its own queue of files to process
+        final private LinkedList<Path> fileQueue = new LinkedList<>();
         FileSpliterator(List<Path> pathsToWalk) {
             super(Long.MAX_VALUE, java.util.Spliterator.NONNULL);
+            // the parent creates the queue that everyone else will share
+            this.dirQueue = new ConcurrentLinkedQueue<>();
             this.dirQueue.addAll(pathsToWalk);
             populateFileQueue();
         }
 
-        private FileSpliterator(ConcurrentLinkedQueue<Path> dirQueue, ConcurrentLinkedQueue<Path> fileQueue) {
+        private FileSpliterator(ConcurrentLinkedQueue<Path> dirQueue) {
             super(Long.MAX_VALUE, java.util.Spliterator.NONNULL);
             this.dirQueue = dirQueue;
-            this.fileQueue = fileQueue;
         }
 
         private long populateFileQueue() {
@@ -103,7 +106,7 @@ public class WildfireFilesCrawler implements Runnable {
                         } else {
                             return false;
                         }
-                    }).limit(POPULATE_QUEUE_SIZE).count();
+                    }).count();
                 } catch (IOException e) {
                     System.err.println("Error listing directory: " + dir + " - " + e.getClass().getName());
                 }
@@ -113,14 +116,14 @@ public class WildfireFilesCrawler implements Runnable {
 
         @Override
         synchronized public boolean tryAdvance(java.util.function.Consumer<? super Path> action) {
-            var path = fileQueue.poll();
+            var path = fileQueue.removeFirst();
             if (path != null) {
                 action.accept(path);
                 return true;
             }
             while (true) {
                 populateFileQueue();
-                path = fileQueue.poll();
+                path = fileQueue.removeFirst();
                 if (path == null && dirQueue.isEmpty()) return false;
                 if (path != null) {
                     action.accept(path);
@@ -131,11 +134,11 @@ public class WildfireFilesCrawler implements Runnable {
 
         @Override
         synchronized public FileSpliterator trySplit() {
-            var count = populateFileQueue();
-            if (count < POPULATE_QUEUE_SIZE) {
-                return null; // Not enough files to split
+            var newSpliterator = new FileSpliterator(this.dirQueue);
+            if (newSpliterator.populateFileQueue() == 0) {
+                return null; // No files to split
             }
-            return new FileSpliterator(this.dirQueue, this.fileQueue);
+            return newSpliterator;
         }
     }
     public void run() {

--- a/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
+++ b/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
@@ -199,16 +199,6 @@ public class WildfireFilesCrawler implements Runnable {
                         status.put(file, ex);
                         return ex;
                     }
-                }).takeWhile(exception -> {
-                    if (exception != null) {
-                        if (exception instanceof WebClientResponseException webException &&
-                                webException.getStatusCode().is4xxClientError()) {
-                            err().println("Unrecoverable authorization error: " + webException.getMessage());
-                            return false;
-                        }
-                        err().println("Error processing file: " + exception.getMessage());
-                    }
-                    return true;
                 }).toList();
             } catch (IOException e) {
                 out().println("There was an exception: " + e.getMessage());

--- a/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
+++ b/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
@@ -116,9 +116,7 @@ public class WildfireFilesCrawler implements Runnable {
         String token = appProps.getProperty("token");
         Instant start = Instant.now();
         ConcurrentHashMap<String, Exception> status = new ConcurrentHashMap<>();
-        ExecutorService executorService = Executors.newFixedThreadPool(parallelism);
         WebClient webClient = Client.getWebClient(metaURL + "/api/metadata", token);
-        Semaphore semaphore = new Semaphore(parallelism);
         AtomicInteger filesCount = new AtomicInteger();
         AtomicInteger crawledCount = new AtomicInteger();
 
@@ -150,39 +148,41 @@ public class WildfireFilesCrawler implements Runnable {
                         map -> (Long) map.get("lastModified"),
                         Long::min));
 
-        try (Stream<String> stream = Files.lines(Paths.get(filesToProcessPath))) {
-            var exceptions = stream.flatMap( fileName -> {
-                File file = new File(fileName);
-                if (file.isDirectory()) {
-                    var nameQueue = new LinkedBlockingQueue<String>();
-                    new WalkerThread(file.toPath(), nameQueue).start();
-                    return Stream.generate(() -> {
-                        try {
-                            return nameQueue.take();
-                        } catch (InterruptedException e) {
-                            return DONE_SENTINEL;
-                        }
-                        // for sentinel value use == not equals!
-                    }).takeWhile(s -> s != DONE_SENTINEL);
-                } else {
-                    return Stream.of(fileName);
-                }
-            }).filter(file -> {
-                try {
-                    if (fileNamesMap.containsKey(file) && fileNamesMap.get(file) >= Files.getLastModifiedTime(Paths.get(file)).toMillis()) {
-                        return false;
+        ForkJoinPool customPool = new ForkJoinPool(parallelism); // set desired parallelism
+
+        var poolResult = customPool.submit(() -> {
+            try (Stream<String> stream = Files.lines(Paths.get(filesToProcessPath))) {
+                var exceptions = stream.flatMap(fileName -> {
+                    File file = new File(fileName);
+                    if (file.isDirectory()) {
+                        var nameQueue = new LinkedBlockingQueue<String>();
+                        new WalkerThread(file.toPath(), nameQueue).start();
+                        return Stream.generate(() -> {
+                            try {
+                                return nameQueue.take();
+                            } catch (InterruptedException e) {
+                                return DONE_SENTINEL;
+                            }
+                            // for sentinel value use == not equals!
+                        }).takeWhile(s -> s != DONE_SENTINEL);
+                    } else {
+                        return Stream.of(fileName);
                     }
-                    return true;
-                } catch (IOException e) {
-                    err().println("Error fetching fileNames or lastModified from map:" + e.getClass().getName());
-                    throw new CommandLine.ExecutionException(cmd(), "Error fetching fileNames or lastModified from map: " + e.getMessage(), e);                }
-            }).map(file -> {
-                try {
-                    semaphore.acquire();
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-                return executorService.submit(() -> {
+                }).filter(file -> {
+                    try {
+                        if (fileNamesMap.containsKey(file) &&
+                                fileNamesMap.get(file) >= Files.getLastModifiedTime(Paths.get(file)).toMillis()) {
+                            return false;
+                        }
+                        return true;
+                    } catch (IOException e) {
+                        err().println("Error fetching fileNames or lastModified from map:" + e.getClass().getName());
+                        throw new CommandLine.ExecutionException(cmd(),
+                                                                 "Error fetching fileNames or lastModified from map: " +
+                                                                         e.getMessage(),
+                                                                 e);
+                    }
+                }).parallel().map(file -> {
                     try {
                         if (crawl(file, webClient, maxReadSize, option, enumLog)) {
                             crawledCount.getAndIncrement();
@@ -193,39 +193,26 @@ public class WildfireFilesCrawler implements Runnable {
                     } catch (Exception ex) {
                         status.put(file, ex);
                         return ex;
-                    } finally {
-                        semaphore.release();
                     }
-                });
-            }).parallel().takeWhile(future -> {
-                                                        try {
-                                                            var exception = future.get();
-                                                            if (exception != null) {
-                                                                if (exception instanceof WebClientResponseException webException &&
-                                                                        webException.getStatusCode().is4xxClientError()) {
-                                                                    err().println("Unrecoverable authorization error: " + webException.getMessage());
-                                                                    return false;
-                                                                }
-                                                                err().println("Error processing file: " + future + " - " + exception.getMessage());
-                                                            }
-                                                        } catch (InterruptedException | ExecutionException e){
-                                                                return false;
-                                                        }
-                                                        return true;
-                                                    }).toList();
-        } catch (IOException e) {
-            out().println("There was an exception: " + e.getMessage());
-        } finally {
-            out().println(filesCount.get() + " valid files found.");
-            out().println("Crawled " + crawledCount.get() + " new files.");
-        }
-        try {
-            semaphore.acquire(parallelism);
-            executorService.shutdown();
-            executorService.awaitTermination(1, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+                }).takeWhile(exception -> {
+                    if (exception != null) {
+                        if (exception instanceof WebClientResponseException webException &&
+                                webException.getStatusCode().is4xxClientError()) {
+                            err().println("Unrecoverable authorization error: " + webException.getMessage());
+                            return false;
+                        }
+                        err().println("Error processing file: " + exception.getMessage());
+                    }
+                    return true;
+                }).toList();
+            } catch (IOException e) {
+                out().println("There was an exception: " + e.getMessage());
+            } finally {
+                out().println(filesCount.get() + " valid files found.");
+                out().println("Crawled " + crawledCount.get() + " new files.");
+            }
+        }).join();
+        customPool.shutdown();
         boolean exceptionFound = false;
         for(var entry : status.entrySet()) {
             if (entry.getValue() != okayException) {

--- a/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
+++ b/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
@@ -70,6 +70,10 @@ public class WildfireFilesCrawler implements Runnable {
         return spec.commandLine();
     }
 
+    /**
+     * this is our own file walker that will skip files that are not accessible, unlike Files.walk().
+     * we use a Spliterator to allow parallel processing of files.
+     */
     static private class FileSpliterator extends java.util.Spliterators.AbstractSpliterator<Path> {
         private static final long POPULATE_QUEUE_SIZE = 1000;
         // all split FileSpliter instances share the same queue of directories to walk

--- a/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
+++ b/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
@@ -13,12 +13,9 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -26,19 +23,17 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 @CommandLine.Command(name = "GET", mixinStandardHelpOptions = true)
 public class WildfireFilesCrawler implements Runnable {
-    @CommandLine.Option(names = "--option", defaultValue = "all", description = "Which information to print - 'all' or 'basic'")
-    private String option;
-    @CommandLine.Parameters(paramLabel = "<file>", description = "Path to the file containing list of NetCDF files to process", arity = "1")
-    private String filesToProcessPath;
     @CommandLine.Option(names = "--metaURL", description = "Host name of the API server", required = true)
     String metaURL;
     @CommandLine.Option(names = "--log", description = "Whether to generate a log")
@@ -47,16 +42,66 @@ public class WildfireFilesCrawler implements Runnable {
     Boolean enumLog = false;
     @CommandLine.Option(names = "--parallelism", description = "Number of threads to use")
     int parallelism = 1;
-
     @CommandLine.Option(names = "--maxReadSize", description = "Number of data elements to read per read call")
     int maxReadSize = 1000000000;
-
-    @CommandLine.Option(names = "--tokenFile", required = true) String tokenFile;
-
-    @CommandLine.Option(names = "--dataset", description = "Whether to initiate dataset collection") boolean initiateDatasetCollection = false;
-
+    @CommandLine.Option(names = "--tokenFile", required = true)
+    String tokenFile;
+    @CommandLine.Option(names = "--dataset", description = "Whether to initiate dataset collection")
+    boolean initiateDatasetCollection = false;
+    @CommandLine.Option(names = "--option", defaultValue = "all", description = "Which information to print - 'all' " +
+            "or 'basic'")
+    private String option;
+    @CommandLine.Parameters(paramLabel = "<file>", description = "Path to the file containing list of NetCDF files to" +
+            " process", arity = "1")
+    private String filesToProcessPath;
     @CommandLine.Spec
     private CommandLine.Model.CommandSpec spec;
+
+    public static void main(String[] args) {
+        CommandLine commandLine = new CommandLine(new WildfireFilesCrawler());
+        commandLine.setExecutionExceptionHandler((ex, cl, pr) -> {
+            System.err.println(ex.getMessage());
+            return 2;
+        });
+        commandLine.setParameterExceptionHandler((ex, as) -> {
+            var t = ex.getCause() != null ? ex.getCause() : ex;
+            System.err.println(t.getMessage());
+            if (t instanceof CommandLine.ParameterException) {
+                commandLine.usage(System.err);
+            }
+            return 1;
+        });
+        System.exit(commandLine.execute(args));
+    }
+
+    public static boolean crawl(String file,
+                                WebClient webClient,
+                                int maxReadSize,
+                                String option,
+                                boolean enumLog) throws InterruptedException, ExecutionException {
+        NetcdfFileReader fileReader = new NetcdfFileReader(file);
+        var metadata = fileReader.processFile(maxReadSize);
+
+        System.out.println("Crawling file: " + file);
+        if (option.equals("all")) {
+            PrintData.printAllData(metadata);
+        } else if (option.equals("basic")) {
+            PrintData.printBasic(metadata);
+        }
+        if (enumLog) {
+            Path enumFile = Paths.get("enumVarList.txt");
+            try {
+                Files.createFile(enumFile);
+            } catch (FileAlreadyExistsException e) {
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            PrintData.printEnums(enumFile, metadata);
+        }
+
+        Client.delete(webClient, file);
+        return (boolean) Client.post(webClient, metadata, new ParameterizedTypeReference<Boolean>() {});
+    }
 
     final PrintWriter out() {
         return cmd().getOut();
@@ -70,16 +115,185 @@ public class WildfireFilesCrawler implements Runnable {
         return spec.commandLine();
     }
 
+    public void run() {
+        var okayException = new Exception("No exception");
+        Properties appProps = new Properties();
+        try {
+            appProps.load(new FileInputStream(tokenFile));
+        } catch (FileNotFoundException e) {
+            throw new CommandLine.PicocliException(tokenFile + " is not a valid file", e);
+        } catch (IOException e) {
+            throw new CommandLine.PicocliException("Error loading properties from token file: " + tokenFile, e);
+        }
+        String token = appProps.getProperty("token");
+        Instant start = Instant.now();
+        ConcurrentHashMap<String, Exception> status = new ConcurrentHashMap<>();
+        WebClient webClient = Client.getWebClient(metaURL + "/api/metadata", token);
+        AtomicInteger filesCount = new AtomicInteger();
+        AtomicInteger crawledCount = new AtomicInteger();
+        AtomicInteger skippedCount = new AtomicInteger();
+
+        List<Map<String, Object>> fileNames = new ArrayList<>();
+        List<Map<String, Object>> newNames;
+        var limit = 10000;
+        var offset = 0;
+        try {
+            do {
+                LinkedMultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+                parameters.add("limit", String.valueOf(limit));
+                parameters.add("offset", String.valueOf(offset));
+                newNames = Client.get(Client.getWebClient(metaURL + "/api/metadata/filenames", token),
+                                      parameters,
+                                      new ParameterizedTypeReference<>() {});
+                fileNames.addAll(newNames);
+                offset += limit;
+            } while (newNames.size() == limit);
+        } catch (Exception e) {
+            err().println("Error fetching file names from metadata service: " + e.getClass().getName());
+            if (e instanceof WebClientResponseException webException &&
+                    webException.getStatusCode().is4xxClientError()) {
+                err().println("Unrecoverable authorization error: " + webException.getMessage());
+            }
+            throw new CommandLine.ExecutionException(cmd(),
+                                                     "Error fetching file names from metadata service: " +
+                                                             e.getMessage(),
+                                                     e);
+        }
+
+        Map<String, Long> fileNamesMap = fileNames.stream()
+                .collect(Collectors.toMap(map -> map.get("fileName").toString(),
+                                          map -> (Long) map.get("lastModified"),
+                                          Long::min));
+
+        ForkJoinPool customPool = new ForkJoinPool(parallelism); // set desired parallelism
+
+        var poolResult = customPool.submit(() -> {
+            try (Stream<String> stream = Files.lines(Paths.get(filesToProcessPath))) {
+                var exceptions = stream.flatMap(fileName -> {
+                    File file = new File(fileName);
+                    if (file.isDirectory()) {
+                        return StreamSupport.stream(new FileSpliterator(List.of(file.toPath())), true)
+                                .map(Path::toString);
+                    } else {
+                        return Stream.of(fileName);
+                    }
+                }).parallel().filter(file -> {
+                    try {
+                        if (fileNamesMap.containsKey(file) &&
+                                fileNamesMap.get(file) >= Files.getLastModifiedTime(Paths.get(file)).toMillis()) {
+                            skippedCount.getAndIncrement();
+                            return false;
+                        }
+                        return true;
+                    } catch (IOException e) {
+                        err().println("Error fetching fileNames or lastModified from map:" + e.getClass().getName());
+                        throw new CommandLine.ExecutionException(cmd(),
+                                                                 "Error fetching fileNames or lastModified from map: " +
+                                                                         e.getMessage(),
+                                                                 e);
+                    }
+                }).map(file -> {
+                    try {
+                        if (crawl(file, webClient, maxReadSize, option, enumLog)) {
+                            crawledCount.getAndIncrement();
+                        }
+                        filesCount.getAndIncrement();
+                        status.put(file, okayException);
+                        return null;
+                    } catch (Exception ex) {
+                        status.put(file, ex);
+                        return ex;
+                    }
+                }).takeWhile(exception -> {
+                    if (exception != null) {
+                        if (exception instanceof WebClientResponseException webException &&
+                                webException.getStatusCode().is4xxClientError()) {
+                            err().println("Unrecoverable authorization error: " + webException.getMessage());
+                            return false;
+                        }
+                        err().println("Error processing file: " + exception + " - " + exception.getClass().getName());
+                    }
+                    return true;
+                }).toList();
+            } catch (IOException e) {
+                out().println("There was an exception: " + e.getMessage());
+            } finally {
+                out().println(filesCount.get() + " valid files found.");
+                out().println("Crawled " + crawledCount.get() + " new files.");
+                out().println("Skipped " + skippedCount.get() + " files already crawled.");
+            }
+        }).join();
+        customPool.shutdown();
+        boolean exceptionFound = false;
+        for (var entry : status.entrySet()) {
+            if (entry.getValue() != okayException) {
+                exceptionFound = true;
+                err().println("Error processing file: " + entry.getKey() + " - " + entry.getValue());
+                if (entry.getValue() instanceof WebClientResponseException webException &&
+                        webException.getStatusCode().is4xxClientError()) {
+                    break;
+                }
+            } else {
+                out().println("Successfully processed file: " + entry.getKey());
+            }
+        }
+        if (log) {
+            try {
+                Path statusFile = Paths.get(filesToProcessPath + ".log");
+                Files.deleteIfExists(statusFile);
+                Files.createFile(statusFile);
+                StringBuilder statusStr = new StringBuilder();
+                status.entrySet().stream().forEach(entry -> {
+                    statusStr.append(entry.getKey() + " -> " + entry.getValue() + System.lineSeparator());
+                });
+                Files.writeString(statusFile, statusStr.toString());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        Instant finish = Instant.now();
+        out().println("Execution Completed in: " + Duration.between(start, finish).toMillis() + "ms");
+
+        if (initiateDatasetCollection) {
+            out().println("Initiating dataset collection");
+            //Write API service to call dataset routing
+            WebClient datasetWebClient = Client.getWebClient(metaURL + "/api/dataset");
+            try {
+                if (metaURL == null) {
+                    out().println("No hostname specified. Skipping dataset update.");
+                } else {
+                    var res = Client.post(datasetWebClient,
+                                          "",
+                                          new ParameterizedTypeReference<Integer>() {},
+                                          httpHeaders -> {
+                                              httpHeaders.setBearerAuth(token);
+                                          });
+                    out().println("RESULT: " + res);
+                }
+            } catch (WebClientRequestException ex) {
+                out().println("Dataset API call: " + ex.getMostSpecificCause() + ex.getMessage());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        if (exceptionFound) {
+            throw new CommandLine.ExecutionException(cmd(),
+                                                     "Error(s) occurred during processing. See above for details.",
+                                                     null);
+        }
+    }
+
     /**
      * this is our own file walker that will skip files that are not accessible, unlike Files.walk().
      * we use a Spliterator to allow parallel processing of files.
      */
     static private class FileSpliterator extends java.util.Spliterators.AbstractSpliterator<Path> {
         private static final long POPULATE_QUEUE_SIZE = 1000;
-        // all split FileSpliter instances share the same queue of directories to walk
+        // all FileSpliterator instances share the same queue of directories to walk
         final private ConcurrentLinkedQueue<Path> dirQueue;
         // each instance has its own queue of files to process
         final private LinkedList<Path> fileQueue = new LinkedList<>();
+
         FileSpliterator(List<Path> pathsToWalk) {
             super(Long.MAX_VALUE, java.util.Spliterator.NONNULL);
             // the parent creates the queue that everyone else will share
@@ -144,195 +358,5 @@ public class WildfireFilesCrawler implements Runnable {
             }
             return newSpliterator;
         }
-    }
-    public void run() {
-        var okayException = new Exception("No exception");
-        Properties appProps = new Properties();
-        try {
-            appProps.load(new FileInputStream(tokenFile));
-        } catch (FileNotFoundException e) {
-            throw new CommandLine.PicocliException(tokenFile + " is not a valid file", e);
-        } catch (IOException e) {
-            throw new CommandLine.PicocliException("Error loading properties from token file: " + tokenFile, e);
-        }
-        String token = appProps.getProperty("token");
-        Instant start = Instant.now();
-        ConcurrentHashMap<String, Exception> status = new ConcurrentHashMap<>();
-        WebClient webClient = Client.getWebClient(metaURL + "/api/metadata", token);
-        AtomicInteger filesCount = new AtomicInteger();
-        AtomicInteger crawledCount = new AtomicInteger();
-        AtomicInteger existingCount = new AtomicInteger();
-
-        List<Map<String, Object>> fileNames =  new ArrayList<>();
-        List<Map<String, Object>> newNames;
-        var limit = 10000;
-        var offset = 0;
-        try {
-            do {
-                LinkedMultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
-                parameters.add("limit", String.valueOf(limit));
-                parameters.add("offset", String.valueOf(offset));
-                newNames = Client.get(Client.getWebClient(metaURL + "/api/metadata/filenames", token), parameters, new ParameterizedTypeReference<>() {});
-                fileNames.addAll(newNames);
-                offset += limit;
-            } while (newNames.size() == limit);
-        } catch (Exception e) {
-            err().println("Error fetching file names from metadata service: " + e.getClass().getName());
-            if (e instanceof WebClientResponseException webException &&
-                    webException.getStatusCode().is4xxClientError()) {
-                err().println("Unrecoverable authorization error: " + webException.getMessage());
-            }
-            throw new CommandLine.ExecutionException(cmd(), "Error fetching file names from metadata service: " + e.getMessage(), e);
-        }
-
-        Map<String, Long> fileNamesMap = fileNames.stream()
-                .collect(Collectors.toMap(
-                        map -> map.get("fileName").toString(),
-                        map -> (Long) map.get("lastModified"),
-                        Long::min));
-
-        ForkJoinPool customPool = new ForkJoinPool(parallelism); // set desired parallelism
-
-        var poolResult = customPool.submit(() -> {
-            try (Stream<String> stream = Files.lines(Paths.get(filesToProcessPath))) {
-                var exceptions = stream.flatMap(fileName -> {
-                    File file = new File(fileName);
-                    if (file.isDirectory()) {
-                         return StreamSupport.stream(new FileSpliterator(List.of(file.toPath())), true).map(Path::toString);
-                    } else {
-                        return Stream.of(fileName);
-                    }
-                }).parallel().filter(file -> {
-                    try {
-                        if (fileNamesMap.containsKey(file) &&
-                                fileNamesMap.get(file) >= Files.getLastModifiedTime(Paths.get(file)).toMillis()) {
-                            existingCount.getAndIncrement();
-                            return false;
-                        }
-                        return true;
-                    } catch (IOException e) {
-                        err().println("Error fetching fileNames or lastModified from map:" + e.getClass().getName());
-                        throw new CommandLine.ExecutionException(cmd(),
-                                                                 "Error fetching fileNames or lastModified from map: " +
-                                                                         e.getMessage(),
-                                                                 e);
-                    }
-                }).map(file -> {
-                    try {
-                        if (crawl(file, webClient, maxReadSize, option, enumLog)) {
-                            crawledCount.getAndIncrement();
-                        }
-                        filesCount.getAndIncrement();
-                        status.put(file, okayException);
-                        return null;
-                    } catch (Exception ex) {
-                        status.put(file, ex);
-                        return ex;
-                    }
-                }).toList();
-            } catch (IOException e) {
-                out().println("There was an exception: " + e.getMessage());
-            } finally {
-                out().println(filesCount.get() + " valid files found.");
-                out().println("Crawled " + crawledCount.get() + " new files.");
-            }
-        }).join();
-        customPool.shutdown();
-        boolean exceptionFound = false;
-        for(var entry : status.entrySet()) {
-            if (entry.getValue() != okayException) {
-                exceptionFound = true;
-                err().println("Error processing file: " + entry.getKey() + " - " + entry.getValue());
-                if (entry.getValue() instanceof WebClientResponseException webException && webException.getStatusCode().is4xxClientError()) {
-                    break;
-                }
-            } else {
-                out().println("Successfully processed file: " + entry.getKey());
-            }
-        }
-        if(log) {
-            try {
-                Path statusFile = Paths.get(filesToProcessPath + ".log");
-                Files.deleteIfExists(statusFile);
-                Files.createFile(statusFile);
-                StringBuilder statusStr = new StringBuilder();
-                status.entrySet().stream().forEach(entry -> {
-                    statusStr.append(entry.getKey() + " -> " + entry.getValue() + System.lineSeparator());
-                });
-                Files.writeString(statusFile, statusStr.toString());
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        Instant finish = Instant.now();
-        out().println("Execution Completed in: "+ Duration.between(start, finish).toMillis() + "ms");
-
-        if(initiateDatasetCollection) {
-            out().println("Initiating dataset collection");
-            //Write API service to call dataset routing
-            WebClient datasetWebClient = Client.getWebClient(metaURL + "/api/dataset");
-            try {
-                if (metaURL == null) {
-                    out().println("No hostname specified. Skipping dataset update.");
-                } else {
-                    var res = Client.post(datasetWebClient, "", new ParameterizedTypeReference<Integer>() {
-                    }, httpHeaders -> {
-                        httpHeaders.setBearerAuth(token);
-                    });
-                    out().println("RESULT: " + res);
-                }
-            } catch (WebClientRequestException ex) {
-                out().println("Dataset API call: " + ex.getMostSpecificCause() + ex.getMessage());
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }
-        if (exceptionFound) {
-            throw new CommandLine.ExecutionException(cmd(), "Error(s) occurred during processing. See above for details.", null);
-        }
-    }
-    public static void main(String[] args) {
-        CommandLine commandLine = new CommandLine(new WildfireFilesCrawler());
-        commandLine.setExecutionExceptionHandler((ex, cl, pr) -> {
-            System.err.println(ex.getMessage());
-            ex.printStackTrace();
-            return 2;
-        });
-        commandLine.setParameterExceptionHandler((ex, as) -> {
-            var t = ex.getCause() != null ? ex.getCause() : ex;
-            System.err.println(t.getMessage());
-            if (t instanceof CommandLine.ParameterException) {
-                commandLine.usage(System.err);
-            }
-            return 1;
-        });
-        System.exit(commandLine.execute(args));
-    }
-
-    public static boolean crawl(String file, WebClient webClient, int maxReadSize, String option, boolean enumLog) throws
-            InterruptedException, ExecutionException {
-        NetcdfFileReader fileReader = new NetcdfFileReader(file);
-        var metadata = fileReader.processFile(maxReadSize);
-
-        System.out.println("Crawling file: " + file);
-        if (option.equals("all")) {
-            PrintData.printAllData(metadata);
-        } else if (option.equals("basic")) {
-            PrintData.printBasic(metadata);
-        }
-        if (enumLog) {
-            Path enumFile = Paths.get("enumVarList.txt");
-            ;
-            try {
-                Files.createFile(enumFile);
-            } catch (FileAlreadyExistsException e) {
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-            PrintData.printEnums(enumFile, metadata);
-        }
-
-        Client.delete(webClient, file);
-        return (boolean) Client.post(webClient, metadata, new ParameterizedTypeReference<Boolean>() {});
     }
 }

--- a/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
+++ b/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
@@ -197,7 +197,7 @@ public class WildfireFilesCrawler implements Runnable {
                         semaphore.release();
                     }
                 });
-            }).takeWhile(future -> {
+            }).parallel().takeWhile(future -> {
                                                         try {
                                                             var exception = future.get();
                                                             if (exception != null) {

--- a/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
+++ b/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
@@ -116,14 +116,14 @@ public class WildfireFilesCrawler implements Runnable {
 
         @Override
         synchronized public boolean tryAdvance(java.util.function.Consumer<? super Path> action) {
-            var path = fileQueue.removeFirst();
+            var path = fileQueue.pollFirst();
             if (path != null) {
                 action.accept(path);
                 return true;
             }
             while (true) {
                 populateFileQueue();
-                path = fileQueue.removeFirst();
+                path = fileQueue.pollFirst();
                 if (path == null && dirQueue.isEmpty()) return false;
                 if (path != null) {
                     action.accept(path);

--- a/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
+++ b/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
@@ -148,6 +148,7 @@ public class WildfireFilesCrawler implements Runnable {
                         map -> (Long) map.get("lastModified"),
                         Long::min));
 
+        out().printf("Processing files %d at a time%n", parallelism);
         ForkJoinPool customPool = new ForkJoinPool(parallelism); // set desired parallelism
 
         var poolResult = customPool.submit(() -> {

--- a/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
+++ b/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
@@ -157,6 +157,7 @@ public class WildfireFilesCrawler implements Runnable {
         WebClient webClient = Client.getWebClient(metaURL + "/api/metadata", token);
         AtomicInteger filesCount = new AtomicInteger();
         AtomicInteger crawledCount = new AtomicInteger();
+        AtomicInteger existingCount = new AtomicInteger();
 
         List<Map<String, Object>> fileNames =  new ArrayList<>();
         List<Map<String, Object>> newNames;
@@ -201,6 +202,7 @@ public class WildfireFilesCrawler implements Runnable {
                     try {
                         if (fileNamesMap.containsKey(file) &&
                                 fileNamesMap.get(file) >= Files.getLastModifiedTime(Paths.get(file)).toMillis()) {
+                            existingCount.getAndIncrement();
                             return false;
                         }
                         return true;

--- a/wildstore-crawl/src/test/java/edu/sjsu/wildstore/CrawlTest.java
+++ b/wildstore-crawl/src/test/java/edu/sjsu/wildstore/CrawlTest.java
@@ -178,7 +178,7 @@ public class CrawlTest {
                         "--tokenFile", userTokenFile.toString(), nameFile.toString());
         Assertions.assertEquals(0, result.exitCode);
         Assertions.assertTrue(result.out.contains("Successfully processed file"));
-        Assertions.assertTrue(result.out.contains((numToCrawl - 1) + " valid files found."));
+        Assertions.assertTrue(result.out.contains((numToCrawl-1) + " valid files found."));
 
         // should be able to crawl all files found in a directory
         result = clirun(WildfireFilesCrawler.class,


### PR DESCRIPTION
use our own implementation of Files.walk

Files.walk fails on unaccessible directories.
we want  to skip them.
the change fully embraces .parallel() streams, so no need for semaphores.
we control parallelism using a threadpool.