### PR TITLE
add type checks to getFilesNames()

### DIFF
--- a/wildstore-meta/src/main/java/edu/sjsu/wildstore/meta/controller/MetadataController.java
+++ b/wildstore-meta/src/main/java/edu/sjsu/wildstore/meta/controller/MetadataController.java
@@ -180,7 +180,9 @@ public class MetadataController {
         if (res.isEmpty()) {
             return List.of();
         }
-        return res.stream().map(dbObject -> {
+        return res.stream()
+                .filter(dbObject -> dbObject.get("fileName") instanceof  String && dbObject.get("lastModified") instanceof Long)
+                .map(dbObject -> {
             String fileName = (String) dbObject.get("fileName");
             Long lastModified = (Long) dbObject.get("lastModified");
             return Map.of("fileName", fileName, "lastModified", lastModified == null ? Long.MIN_VALUE : lastModified);


### PR DESCRIPTION
we do unchecked casts in getFileNames().
add a filter to only look at records with the correct type.