### PR TITLE
Add top-level React error boundary

### DIFF
--- a/wildstore-meta/app/src/components/error-boundary/ErrorBoundary.jsx
+++ b/wildstore-meta/app/src/components/error-boundary/ErrorBoundary.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('ErrorBoundary caught an error:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex items-center justify-center min-h-screen bg-base-200">
+          <div className="text-center p-8">
+            <h1 className="text-2xl font-bold mb-4">Something went wrong</h1>
+            <p className="mb-4">An unexpected error occurred.</p>
+            <button
+              className="btn btn-primary"
+              onClick={() => window.location.reload()}
+            >
+              Refresh Page
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/wildstore-meta/app/src/index.js
+++ b/wildstore-meta/app/src/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import ErrorBoundary from './components/error-boundary/ErrorBoundary';
 import reportWebVitals from './reportWebVitals';
 import { Provider } from 'react-redux';
 import { store } from './redux/store';
@@ -9,7 +10,9 @@ import { store } from './redux/store';
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
     <Provider store={store}>
-      <App />
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
     </Provider>
 );
 


### PR DESCRIPTION
## Summary
- Add `ErrorBoundary` class component that catches unhandled render errors
- Wrap the app in `index.js` so any rendering crash shows a fallback UI ("Something went wrong") with a refresh button instead of a blank screen
- Uses Tailwind/DaisyUI classes consistent with the rest of the app

## Not addressed
- Per-feature error boundaries (map view, search results) — the top-level boundary is sufficient for now and avoids overcomplicating the component tree

## Test plan
- [x] Frontend builds cleanly (`npx react-scripts build`)

Closes #120