### PR TITLE
Add generic file type crawling with tests

### DIFF
--- a/wildstore-common/src/main/java/edu/sjsu/wildstore/BasicFileReader.java
+++ b/wildstore-common/src/main/java/edu/sjsu/wildstore/BasicFileReader.java
@@ -5,16 +5,19 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
-public class GenericFileReader {
-    private String filePath;
-    private DigestingRandomAccessFile randomAccessFile;
-    public DigestingRandomAccessFile getRandomAccessFile() {
-        return randomAccessFile;
+public class BasicFileReader implements FileReader {
+    private final String filePath;
+
+    public BasicFileReader(String filePath) {
+        this.filePath = filePath;
     }
 
-    public GenericFileReader(String filePath) {this.filePath = filePath;}
+    @Override
+    public void processFileContents(Metadata metadata, int maxReadSize) {}
 
-    public Metadata processFile() {
+    @Override
+    public Metadata processMetadata() {
+        DigestingRandomAccessFile randomAccessFile;
         try {
             randomAccessFile = new DigestingRandomAccessFile(filePath);
         } catch (IOException e) {
@@ -22,8 +25,6 @@ public class GenericFileReader {
         }
 
         Metadata metadata = new Metadata();
-        // no global attributes to extract,
-        // only records the filename, file size, last modified time, and a digest (checksum)
         metadata.globalAttributes = List.of();
         File file = new File(filePath);
         metadata.fileName = Set.of(filePath);
@@ -34,7 +35,6 @@ public class GenericFileReader {
             metadata.digestString = randomAccessFile.getDigestString(true);
         } catch (IOException e) {
             metadata.digestString = null;
-            System.out.println("No digest was found for this file.");
             throw new RuntimeException(e);
         }
 

--- a/wildstore-common/src/main/java/edu/sjsu/wildstore/FileReader.java
+++ b/wildstore-common/src/main/java/edu/sjsu/wildstore/FileReader.java
@@ -1,0 +1,27 @@
+package edu.sjsu.wildstore;
+
+public interface FileReader {
+
+    /**
+     * Processes common file metadata (filename, path, size, timestamps, digest).
+     * All implementations must provide this method.
+     */
+    Metadata processMetadata();
+
+    /**
+     * Reads and processes file-type-specific contents into the provided metadata object.
+     * Override to add content parsing for a specific file type.
+     * By default, it does nothing.
+     */
+    void processFileContents(Metadata metadata, int maxReadSize);
+
+    /**
+     * Process the file that calls the metaData method, processMetadata and the read method, processFileContents
+     * returns the resulting metadata.
+     */
+    default Metadata processFile(int maxReadSize) {
+        Metadata metadata = processMetadata();
+        processFileContents(metadata, maxReadSize);
+        return metadata;
+    }
+}

--- a/wildstore-common/src/main/java/edu/sjsu/wildstore/GenericFileReader.java
+++ b/wildstore-common/src/main/java/edu/sjsu/wildstore/GenericFileReader.java
@@ -2,6 +2,7 @@ package edu.sjsu.wildstore;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 
 public class GenericFileReader {
@@ -21,6 +22,9 @@ public class GenericFileReader {
         }
 
         Metadata metadata = new Metadata();
+        // no global attributes to extract,
+        // only records the filename, file size, last modified time, and a digest (checksum)
+        metadata.globalAttributes = List.of();
         File file = new File(filePath);
         metadata.fileName = Set.of(filePath);
         metadata.filePath = Set.of(filePath.substring(0, filePath.lastIndexOf('/') + 1));

--- a/wildstore-common/src/main/java/edu/sjsu/wildstore/GenericFileReader.java
+++ b/wildstore-common/src/main/java/edu/sjsu/wildstore/GenericFileReader.java
@@ -1,0 +1,39 @@
+package edu.sjsu.wildstore;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+
+public class GenericFileReader {
+    private String filePath;
+    private DigestingRandomAccessFile randomAccessFile;
+    public DigestingRandomAccessFile getRandomAccessFile() {
+        return randomAccessFile;
+    }
+
+    public GenericFileReader(String filePath) {this.filePath = filePath;}
+
+    public Metadata processFile() {
+        try {
+            randomAccessFile = new DigestingRandomAccessFile(filePath);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        Metadata metadata = new Metadata();
+        File file = new File(filePath);
+        metadata.fileName = Set.of(filePath);
+        metadata.filePath = Set.of(filePath.substring(0, filePath.lastIndexOf('/') + 1));
+        metadata.fileSize = file.length();
+        metadata.lastModified = file.lastModified();
+        try {
+            metadata.digestString = randomAccessFile.getDigestString(true);
+        } catch (IOException e) {
+            metadata.digestString = null;
+            System.out.println("No digest was found for this file.");
+            throw new RuntimeException(e);
+        }
+
+        return metadata;
+    }
+}

--- a/wildstore-common/src/main/java/edu/sjsu/wildstore/NetcdfFileReader.java
+++ b/wildstore-common/src/main/java/edu/sjsu/wildstore/NetcdfFileReader.java
@@ -22,7 +22,7 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class NetcdfFileReader {
+public class NetcdfFileReader implements FileReader {
     private final String netcdfFilepath;
     private long maxReadSize = 1000000000;
     private static final int ENUM_THRESHOLD = 20;
@@ -36,8 +36,8 @@ public class NetcdfFileReader {
         this.netcdfFilepath = netcdfFilepath;
     }
 
-    public Metadata processFile(int maxReadSize) {
-        // Try and read the contents of the netCDF file
+    @Override
+    public Metadata processMetadata() {
         try {
             var method = NetcdfFile.class.getDeclaredMethod("open", RandomAccessFile.class, String.class, CancelTask.class, Object.class);
             method.setAccessible(true);
@@ -48,9 +48,7 @@ public class NetcdfFileReader {
             throw new RuntimeException(e);
         }
 
-        this.maxReadSize = maxReadSize;
         Metadata metadata = new Metadata();
-        String fileNameStr = netcdfFilepath.substring(netcdfFilepath.lastIndexOf('/') + 1);
         metadata.fileName = Set.of(netcdfFilepath);
         metadata.filePath = Set.of(netcdfFilepath.substring(0, netcdfFilepath.lastIndexOf('/') + 1));
 
@@ -59,8 +57,15 @@ public class NetcdfFileReader {
         metadata.fileSize = file.length();
         metadata.lastModified = file.lastModified();
 
-        metadata.globalAttributes = readGlobalAttributes();
+        return metadata;
+    }
 
+    @Override
+    public void processFileContents(Metadata metadata, int maxReadSize) {
+        this.maxReadSize = maxReadSize;
+        String fileNameStr = netcdfFilepath.substring(netcdfFilepath.lastIndexOf('/') + 1);
+
+        metadata.globalAttributes = readGlobalAttributes();
         metadata.variables = readVariables();
 
         //Special processing @Todo: Find a more efficient way to do this
@@ -151,8 +156,6 @@ public class NetcdfFileReader {
             System.out.println("No digest was found for this file.");
             throw new RuntimeException(e);
         }
-
-        return metadata;
     }
 
     public List<WildfireAttribute> readGlobalAttributes() {

--- a/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
+++ b/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
@@ -24,6 +24,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
@@ -35,6 +36,13 @@ import java.util.stream.StreamSupport;
 
 @CommandLine.Command(name = "GET", mixinStandardHelpOptions = true)
 public class WildfireFilesCrawler implements Runnable {
+    private static final Set<String> SUPPORTED_EXTENSIONS = Set.of(
+        ".nc",           // NetCDF
+        ".hdf5", ".h5",  // HDF5
+        ".shp",          // Shapefile
+        ".tif", ".tiff", // GeoTIFF
+        ".kmz"           // KMZ
+    );
     @CommandLine.Option(names = "--metaURL", description = "Host name of the API server", required = true)
     String metaURL;
     @CommandLine.Option(names = "--log", description = "Whether to generate a log")
@@ -88,8 +96,10 @@ public class WildfireFilesCrawler implements Runnable {
                                 int maxReadSize,
                                 String option,
                                 boolean enumLog) throws InterruptedException, ExecutionException {
-        NetcdfFileReader fileReader = new NetcdfFileReader(file);
-        var metadata = fileReader.processFile(maxReadSize);
+        if (SUPPORTED_EXTENSIONS.stream().noneMatch(file::endsWith)) {return false;}
+        var metadata = file.endsWith(".nc")
+                       ? new NetcdfFileReader(file).processFile(maxReadSize)
+                       : new GenericFileReader(file).processFile();
 
         System.out.println("Crawling file: " + file);
         if (option.equals("all")) {
@@ -334,7 +344,8 @@ public class WildfireFilesCrawler implements Runnable {
                             dirQueue.add(p);
                             return false;
                         } else if (Files.isRegularFile(p, LinkOption.NOFOLLOW_LINKS) &&
-                                Files.isReadable(p) && p.toString().endsWith(".nc")) {
+                                Files.isReadable(p) &&
+                                SUPPORTED_EXTENSIONS.stream().anyMatch(p.toString()::endsWith)) {
                             fileQueue.add(p);
                             return true;
                         } else {

--- a/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
+++ b/wildstore-crawl/src/main/java/edu/sjsu/wildstore/WildfireFilesCrawler.java
@@ -24,9 +24,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Function;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -36,12 +36,14 @@ import java.util.stream.StreamSupport;
 
 @CommandLine.Command(name = "GET", mixinStandardHelpOptions = true)
 public class WildfireFilesCrawler implements Runnable {
-    private static final Set<String> SUPPORTED_EXTENSIONS = Set.of(
-        ".nc",           // NetCDF
-        ".hdf5", ".h5",  // HDF5
-        ".shp",          // Shapefile
-        ".tif", ".tiff", // GeoTIFF
-        ".kmz"           // KMZ
+    private static final Map<String, Function<String, FileReader>> FILE_READERS = Map.of(
+        ".nc",   NetcdfFileReader::new,
+        ".hdf5", BasicFileReader::new,
+        ".h5",   BasicFileReader::new,
+        ".shp",  BasicFileReader::new,
+        ".tif",  BasicFileReader::new,
+        ".tiff", BasicFileReader::new,
+        ".kmz",  BasicFileReader::new
     );
     @CommandLine.Option(names = "--metaURL", description = "Host name of the API server", required = true)
     String metaURL;
@@ -96,10 +98,13 @@ public class WildfireFilesCrawler implements Runnable {
                                 int maxReadSize,
                                 String option,
                                 boolean enumLog) throws InterruptedException, ExecutionException {
-        if (SUPPORTED_EXTENSIONS.stream().noneMatch(file::endsWith)) {return false;}
-        var metadata = file.endsWith(".nc")
-                       ? new NetcdfFileReader(file).processFile(maxReadSize)
-                       : new GenericFileReader(file).processFile();
+        var supportedFile = FILE_READERS.entrySet().stream()
+                .filter(e -> file.endsWith(e.getKey()))
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .orElse(null);
+        if (supportedFile == null) {return false;}
+        var metadata = supportedFile.apply(file).processFile(maxReadSize);
 
         System.out.println("Crawling file: " + file);
         if (option.equals("all")) {
@@ -345,7 +350,7 @@ public class WildfireFilesCrawler implements Runnable {
                             return false;
                         } else if (Files.isRegularFile(p, LinkOption.NOFOLLOW_LINKS) &&
                                 Files.isReadable(p) &&
-                                SUPPORTED_EXTENSIONS.stream().anyMatch(p.toString()::endsWith)) {
+                                FILE_READERS.keySet().stream().anyMatch(p.toString()::endsWith)) {
                             fileQueue.add(p);
                             return true;
                         } else {

--- a/wildstore-crawl/src/test/java/edu/sjsu/wildstore/CrawlTest.java
+++ b/wildstore-crawl/src/test/java/edu/sjsu/wildstore/CrawlTest.java
@@ -220,15 +220,15 @@ public class CrawlTest {
     }
 
     @Test
-    public void testGenericCrawl() throws IOException {
+    public void testBasicCrawl() throws IOException {
         String userToken = "secret-user-token";
         createUser("ROLE_USER", "user", "user@crawl", userToken);
 
         var userTokenFile = tempDir.resolve("user-token.txt");
         Files.write(userTokenFile, ("token=" + userToken).getBytes());
 
-        // Create generic test files (HDF5, shapefiles, GeoTIFFs, KMZ) in tempNameDir
-        var genericDir = tempNameDir.resolve("generic-data");
+        // Create basic test files (HDF5, shapefiles, GeoTIFFs, KMZ) in tempNameDir
+        var genericDir = tempNameDir.resolve("basic-data");
         Files.createDirectories(genericDir);
 
         var hdf5File  = genericDir.resolve("testData.h5");
@@ -257,7 +257,7 @@ public class CrawlTest {
         var singleFile = tempNameDir.resolve("genericSingleFile.txt");
         Files.write(singleFile, hdf5File.toAbsolutePath().toString().getBytes());
 
-        // user should be able to crawl generic files
+        // user should be able to crawl basic files
         var result = clirun(WildfireFilesCrawler.class,
                         "--metaURL", metaURL,
                         "--tokenFile", userTokenFile.toString(), nameFile.toString());
@@ -278,11 +278,11 @@ public class CrawlTest {
         Assertions.assertEquals(0, result.exitCode);
         Assertions.assertTrue(result.out.contains("0 valid files found."));
         Assertions.assertTrue(result.out.contains("Crawled 0 new files."));
-        // all 6 generic files skipped, .txt not counted at all
+        // all 6 basic files skipped, .txt not counted at all
         System.out.println("Test skipping: " +result.out);
         Assertions.assertTrue(result.out.contains("Skipped " + numToCrawl + " files already crawled."));
 
-        // should re-crawl a generic file with a later lastModified date
+        // should re-crawl a basic file with a later lastModified date
         var metaDataCount = springCtx.getBean(MongoTemplate.class).getCollection("metadata").countDocuments();
         Files.write(hdf5File, "updated hdf5 content".getBytes());
         Files.setLastModifiedTime(hdf5File, FileTime.from(Instant.now().plusSeconds(2)));

--- a/wildstore-crawl/src/test/java/edu/sjsu/wildstore/CrawlTest.java
+++ b/wildstore-crawl/src/test/java/edu/sjsu/wildstore/CrawlTest.java
@@ -219,6 +219,85 @@ public class CrawlTest {
         Assertions.assertTrue(result.out.contains("Skipped " + expected + " files already crawled."));
     }
 
+    @Test
+    public void testGenericCrawl() throws IOException {
+        String userToken = "secret-user-token";
+        createUser("ROLE_USER", "user", "user@crawl", userToken);
+
+        var userTokenFile = tempDir.resolve("user-token.txt");
+        Files.write(userTokenFile, ("token=" + userToken).getBytes());
+
+        // Create generic test files (HDF5, shapefiles, GeoTIFFs, KMZ) in tempNameDir
+        var genericDir = tempNameDir.resolve("generic-data");
+        Files.createDirectories(genericDir);
+
+        var hdf5File  = genericDir.resolve("testData.h5");
+        var hdf5File2 = genericDir.resolve("testData.hdf5");
+        var shpFile   = genericDir.resolve("testData.shp");
+        var tifFile   = genericDir.resolve("testData.tif");
+        var tiffFile  = genericDir.resolve("testData.tiff");
+        var kmzFile   = genericDir.resolve("testData.kmz");
+        Files.write(hdf5File,  "test hdf5 content".getBytes());
+        Files.write(hdf5File2, "test hdf5 content 2".getBytes());
+        Files.write(shpFile,   "test shapefile content".getBytes());
+        Files.write(tifFile,   "test geotiff content".getBytes());
+        Files.write(tiffFile,  "test geotiff content 2".getBytes());
+        Files.write(kmzFile,   "test kmz content".getBytes());
+
+        var genericFiles = List.of(hdf5File.toString(), hdf5File2.toString(), shpFile.toString(),
+                                   tifFile.toString(), tiffFile.toString(), kmzFile.toString());
+        int numToCrawl = genericFiles.size();
+
+        var nameFile = tempNameDir.resolve("genericFileNames.txt");
+        Files.write(nameFile, String.join("\n", genericFiles).getBytes());
+
+        var dirFile = tempNameDir.resolve("genericDirName.txt");
+        Files.write(dirFile, genericDir.toAbsolutePath().toString().getBytes());
+
+        var singleFile = tempNameDir.resolve("genericSingleFile.txt");
+        Files.write(singleFile, hdf5File.toAbsolutePath().toString().getBytes());
+
+        // user should be able to crawl generic files
+        var result = clirun(WildfireFilesCrawler.class,
+                        "--metaURL", metaURL,
+                        "--tokenFile", userTokenFile.toString(), nameFile.toString());
+        Assertions.assertEquals(0, result.exitCode);
+        Assertions.assertTrue(result.out.contains("Successfully processed file"));
+        Assertions.assertTrue(result.out.contains(numToCrawl + " valid files found."));
+        Assertions.assertTrue(result.out.contains("Crawled " + numToCrawl + " new files."));
+        Assertions.assertTrue(result.out.contains("Skipped 0 files already crawled."));
+
+        // unsupported file types in the directory should be silently ignored
+        var unsupportedFile = genericDir.resolve("ignored.txt");
+        Files.write(unsupportedFile, "this file should be ignored".getBytes());
+
+        // should skip already-crawled files and ignore unsupported types when crawling directory
+        result = clirun(WildfireFilesCrawler.class,
+                        "--metaURL", metaURL,
+                        "--tokenFile", userTokenFile.toString(), dirFile.toString());
+        Assertions.assertEquals(0, result.exitCode);
+        Assertions.assertTrue(result.out.contains("0 valid files found."));
+        Assertions.assertTrue(result.out.contains("Crawled 0 new files."));
+        // all 6 generic files skipped, .txt not counted at all
+        System.out.println("Test skipping: " +result.out);
+        Assertions.assertTrue(result.out.contains("Skipped " + numToCrawl + " files already crawled."));
+
+        // should re-crawl a generic file with a later lastModified date
+        var metaDataCount = springCtx.getBean(MongoTemplate.class).getCollection("metadata").countDocuments();
+        Files.write(hdf5File, "updated hdf5 content".getBytes());
+        Files.setLastModifiedTime(hdf5File, FileTime.from(Instant.now().plusSeconds(2)));
+
+        result = clirun(WildfireFilesCrawler.class,
+                        "--metaURL", metaURL,
+                        "--tokenFile", userTokenFile.toString(), singleFile.toString());
+        Assertions.assertEquals(0, result.exitCode);
+        Assertions.assertTrue(result.out.contains("1 valid files found."));
+        Assertions.assertTrue(result.out.contains("Crawled 1 new files."));
+        Assertions.assertTrue(result.out.contains("Skipped 0 files already crawled."));
+        // re-crawling an existing file should update, not insert a new document
+        Assertions.assertEquals(metaDataCount, springCtx.getBean(MongoTemplate.class).getCollection("metadata").countDocuments());
+    }
+
     private static void createUser(String role, String name, String email, String token) {
         // add the token to the db, so everything should work
         var rec = Map.of("role", role,


### PR DESCRIPTION
**Summary**:  
- Extended the simple crawler to support non-NetCDF file types: HDF5 (.h5, .hdf5), shapefiles (.shp), GeoTIFFs (.tif, .tiff), and KMZ (.kmz) via GenericFileReader
-  Records filename, file size, last modified time, and computes the digest of the file
-  Added test to verify all 6 supported extensions are crawled correctly, already-crawled files are skipped, unsupported file types (e.g. .txt) in a directory are ignored, and a file with an updated lastModified is re-crawled without inserting a duplicate document

**Test plan**:
- Run `mvn test`