### PR TITLE
Predicate container

### DIFF
--- a/wildstore-meta/app/src/components/autocomplete/autocomplete.jsx
+++ b/wildstore-meta/app/src/components/autocomplete/autocomplete.jsx
@@ -39,12 +39,12 @@ const Autocomplete = ({ items, value, onChange, onOpenChange}) => {
           onChange={(e) => {
             onChange(e);
             filter(e);
-            handleOpen()
+            handleOpen();
           }}
           onFocus={(e) => {
             onChange(e);
             filter(e);
-            handleOpen()
+            handleOpen();
           }}
           onBlur={() => handleClose()}
           placeholder="variable"

--- a/wildstore-meta/app/src/components/autocomplete/autocomplete.jsx
+++ b/wildstore-meta/app/src/components/autocomplete/autocomplete.jsx
@@ -30,7 +30,7 @@ const Autocomplete = ({ items, value, onChange, onOpenChange}) => {
     <div className="join-item">
       <div
         ref={ref}
-        className={classNames("dropdown w-full relative z-[1000]", { "dropdown-open": open })}
+        className={classNames("dropdown w-full relative", { "dropdown-open": open })}
       >
         <input
           type="text"

--- a/wildstore-meta/app/src/components/autocomplete/autocomplete.jsx
+++ b/wildstore-meta/app/src/components/autocomplete/autocomplete.jsx
@@ -1,11 +1,19 @@
 import { useRef, memo, useState } from "react";
 import classNames from "classnames";
+import TooltipPortal from '../tooltip-portal/TooltipPortal';
 
-const Autocomplete = ({ items, value, onChange }) => {
+const Autocomplete = ({ items, value, onChange, onOpenChange}) => {
   const ref = useRef(null);
   const [open, setOpen] = useState(false);
   const [filteredItems, setFilteredItems] = useState([...items]);
-
+  const handleOpen = () => {
+    setOpen(true);
+    onOpenChange?.(true);
+  };
+  const handleClose = () => {
+    setOpen(false);
+    onOpenChange?.(false);
+  };
   const filter = (e) => {
     const varName = e.target.value;
     if (varName) {
@@ -22,7 +30,7 @@ const Autocomplete = ({ items, value, onChange }) => {
     <div className="join-item">
       <div
         ref={ref}
-        className={classNames("dropdown w-full relative z-30", { "dropdown-open": open })}
+        className={classNames("dropdown w-full relative z-50", { "dropdown-open": open })}
       >
         <input
           type="text"
@@ -31,20 +39,20 @@ const Autocomplete = ({ items, value, onChange }) => {
           onChange={(e) => {
             onChange(e);
             filter(e);
-            setOpen(true);
+            handleOpen()
           }}
           onFocus={(e) => {
             onChange(e);
             filter(e);
-            setOpen(true);
+            handleOpen()
           }}
-          onBlur={() => setOpen(false)}
+          onBlur={() => handleClose()}
           placeholder="variable"
           tabIndex={0}
         />
 
         <div
-          className="dropdown-content border border-base-200 top-14 overflow-y-scroll h-40 flex-col rounded-md absolute z-50 bg-white -mt-2 !w-[250%]"
+          className="dropdown-content border border-base-200 top-14 overflow-y-scroll h-40 flex-col rounded-md absolute z-50 bg-white -mt-2 !w-[150%]"
         >
           <ul
             className="w-full menu menu-compact last:border-b-0"
@@ -54,19 +62,17 @@ const Autocomplete = ({ items, value, onChange }) => {
                 key={item.value}
                 tabIndex={index + 1}
                 onClick={(e) => {
-                  setOpen(false);
+                  handleClose();
                   onChange(e);
                   filter(e);
                 }}
                 className="border-b border-b-base-content/10 w-full"
               >
-                <button
-                  className="before:z-5000 before:content-[attr(data-tip)] tooltip tooltip-right"
-                  data-tip={item.value}
-                  value={item.label}
-                >
-                  {item.label}
-                </button>
+                <TooltipPortal content={item.value}>
+                  <button>
+                    {item.label}
+                  </button>
+                </TooltipPortal>
               </li>
             ))}
           </ul>

--- a/wildstore-meta/app/src/components/autocomplete/autocomplete.jsx
+++ b/wildstore-meta/app/src/components/autocomplete/autocomplete.jsx
@@ -30,7 +30,7 @@ const Autocomplete = ({ items, value, onChange, onOpenChange}) => {
     <div className="join-item">
       <div
         ref={ref}
-        className={classNames("dropdown w-full relative z-50", { "dropdown-open": open })}
+        className={classNames("dropdown w-full relative z-[1000]", { "dropdown-open": open })}
       >
         <input
           type="text"
@@ -52,7 +52,7 @@ const Autocomplete = ({ items, value, onChange, onOpenChange}) => {
         />
 
         <div
-          className="dropdown-content border border-base-200 top-14 overflow-y-scroll h-40 flex-col rounded-md absolute z-50 bg-white -mt-2 !w-[150%]"
+          className="dropdown-content border border-base-200 top-14 overflow-y-scroll h-40 flex-col rounded-md absolute z-[1000] bg-white -mt-2 !w-[150%]"
         >
           <ul
             className="w-full menu menu-compact last:border-b-0"
@@ -61,10 +61,11 @@ const Autocomplete = ({ items, value, onChange, onOpenChange}) => {
               <li
                 key={item.value}
                 tabIndex={index + 1}
-                onClick={(e) => {
+                onMouseDown={(e) => {
+                  e.preventDefault();
                   handleClose();
-                  onChange(e);
-                  filter(e);
+                  onChange({ target: { value: item.label } });
+                  filter({ target: { value: item.label } });
                 }}
                 className="border-b border-b-base-content/10 w-full"
               >

--- a/wildstore-meta/app/src/components/autocomplete/autocomplete.jsx
+++ b/wildstore-meta/app/src/components/autocomplete/autocomplete.jsx
@@ -2,17 +2,15 @@ import { useRef, memo, useState } from "react";
 import classNames from "classnames";
 import TooltipPortal from '../tooltip-portal/TooltipPortal';
 
-const Autocomplete = ({ items, value, onChange, onOpenChange}) => {
+const Autocomplete = ({ items, value, onChange }) => {
   const ref = useRef(null);
   const [open, setOpen] = useState(false);
   const [filteredItems, setFilteredItems] = useState([...items]);
   const handleOpen = () => {
     setOpen(true);
-    onOpenChange?.(true);
   };
   const handleClose = () => {
     setOpen(false);
-    onOpenChange?.(false);
   };
   const filter = (e) => {
     const varName = e.target.value;

--- a/wildstore-meta/app/src/components/filter/filter.jsx
+++ b/wildstore-meta/app/src/components/filter/filter.jsx
@@ -72,7 +72,7 @@ const Filter = () => {
     }
 
     return (
-        <div className="flex flex-col content-between flex-wrap">
+        <div className="flex flex-col justify-between flex-wrap">
             <div className='flex flex-col gap-4'>
                 {components.map((component, index) => (
                     <Predicate

--- a/wildstore-meta/app/src/components/predicate/predicate.jsx
+++ b/wildstore-meta/app/src/components/predicate/predicate.jsx
@@ -17,7 +17,7 @@ const Predicate = ({ component, onChange, onAdd, items, onToggle, onDelete, show
     };
 
     return (
-        <div className="join">
+      <div className="flex flex-wrap lg:flex-nowrap items-center gap-3 w-full">
             <div className="flex-none">
                 <button className="btn join-item" 
                   onClick={(e) => {
@@ -27,7 +27,7 @@ const Predicate = ({ component, onChange, onAdd, items, onToggle, onDelete, show
                 </button>
             </div>
             <div className="flex-auto w-36">
-                <Autocomplete value={component.varName} 
+                <Autocomplete value={component.varName}
                   onChange={(e) => handleInputChange('varName', e)}
                   items={items} />
             </div>

--- a/wildstore-meta/app/src/components/tooltip-portal/TooltipPortal.jsx
+++ b/wildstore-meta/app/src/components/tooltip-portal/TooltipPortal.jsx
@@ -1,0 +1,49 @@
+import { useState, useRef, useEffect } from "react";
+import { createPortal } from "react-dom";
+
+export default function TooltipPortal({ children, content }) {
+  const [visible, setVisible] = useState(false);
+  const [position, setPosition] = useState({ top: 0, left: 0 });
+  const ref = useRef(null);
+
+  useEffect(() => {
+    if (!visible) return;
+
+    const rect = ref.current.getBoundingClientRect();
+
+    setPosition({
+      top: rect.top + window.scrollY + rect.height / 2,
+      left: rect.right + window.scrollX + 8
+    });
+  }, [visible]);
+
+  return (
+    <>
+      <span
+        ref={ref}
+        onMouseEnter={() => setVisible(true)}
+        onMouseLeave={() => setVisible(false)}
+        className="inline-block"
+      >
+        {children}
+      </span>
+
+      {visible &&
+        createPortal(
+          <div
+            style={{
+              position: "absolute",
+              top: position.top,
+              left: position.left,
+              transform: "translateY(-50%)",
+              zIndex: 51
+            }}
+            className="px-2 py-1 text-sm bg-gray-800 text-white rounded shadow-lg whitespace-normal break-words max-w-[170px]"
+          >
+            {content}
+          </div>,
+          document.body
+        )}
+    </>
+  );
+}

--- a/wildstore-meta/app/src/components/workspace/workspace.jsx
+++ b/wildstore-meta/app/src/components/workspace/workspace.jsx
@@ -144,8 +144,8 @@ const Workspace = () => {
                     })}
                 </div>
             </div>
-            <div className="h-fit">
-                <div className="collapse collapse-arrow rounded-none">
+            <div>
+                <div className="collapse collapse-arrow rounded-none !overflow-visible">
                     <input type="checkbox" defaultChecked />
                     <div className="collapse-title text-xl font-medium">
                         <div className='flex gap-4 items-center'>
@@ -153,7 +153,7 @@ const Workspace = () => {
                             Filters
                         </div>
                     </div>
-                    <div className="collapse-content">
+                    <div className="collapse-content !overflow-visible">
                         <Filter />
                     </div>
                 </div>

--- a/wildstore-meta/app/src/components/workspace/workspace.jsx
+++ b/wildstore-meta/app/src/components/workspace/workspace.jsx
@@ -147,7 +147,7 @@ const Workspace = () => {
             <div>
                 <div className="collapse collapse-arrow rounded-none !overflow-visible">
                     <input type="checkbox" defaultChecked />
-                    <div className="collapse-title text-xl font-medium">
+                    <div className="collapse-title text-xl font-medium !overflow-visible">
                         <div className='flex gap-4 items-center'>
                             <GoFilter size={20} />
                             Filters


### PR DESCRIPTION
Previously, dropdown menu got clipped by the search results. Now, it is layered on top so whole menu can be seen. 

Previously, Tooltip is limited to same width of the dropdown menu so it cant be seen. Now, Tooltip converted to portal so it doesnt get clipped.

Previously, predicate section was not adjusted to fit the width size of the search area box. Now, predicate section is evenly distributed across the width.

Previously, when selecting a variable in the dropdown menu, nothing happened. Now, variable is automatically filled into the text box after selection. 

